### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ their own assumptions (e.g. BRAIN).
 ## Overview
 
 OBO Graphs (OGs) are a graph-oriented way of representing ontologies
-or portions of ontologies in a developer-friendly JSON (or YAML). A
+or portions of ontologies in a developer-friendly JSON (or YAML) format. A
 typical consumer may be a Python developer using ontologies to enhance
 an analysis tool, database search/infrastructure etc.
 
@@ -88,8 +88,8 @@ The basic form is:
 ]
 ```
 
-Here is an example of a subgraph of Uberon consisting of two nodes and one
-part-of edge:
+Here is an example of a subgraph of Uberon consisting of four nodes, two 
+part-of and two is_a edges:
 
 
 ```
@@ -199,7 +199,7 @@ Currently two axiom patterns are defined:
 
 Note that these do not necessarily correspond 1:1 to OWL axiom
 types. The two above are different forms of equivalent classes axiom,
-the former suited to cases where we have multiple ontologies with overlapping
+the former suited to cases where we have multiple ontologies with overlapping (... truncated sentence)
 
 See [README-owlmapping.md](README-owlmapping.md) for mor details
 


### PR DESCRIPTION
Why do you use "lbl" as a key for the term/class name? Why not "name"? Also, I would be in favor of using 
"subject", "predicate" and "object" instead of the three-character abbreviations. It'll be just a tad clearer.

I would add in the motivation-section that JSON is a very popular syntax that has a lot of support in various software. 
It is more expressive than the OBO syntax and less complicated than OWL.

OBO is a subset of OWL, i.e. OWL is a superset thus can express all axioms found in OBO. How does OBO Graph compare with OWL? can they both express each other's axioms and properties? Are they equivalent? Can I convert from one to the other and back and arrive at the same state?