### PR TITLE
Added codes that interpret objects of property rdfs:subClassOf as nodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
           <docletArtifact>
             <groupId>ch.raffael.pegdown-doclet</groupId>
             <artifactId>pegdown-doclet</artifactId>
-            <version>1.1</version>
+            <version>1.3</version>
           </docletArtifact>
           <useStandardDocletOptions>true</useStandardDocletOptions>
         </configuration>

--- a/src/main/java/org/geneontology/obographs/owlapi/FromOwl.java
+++ b/src/main/java/org/geneontology/obographs/owlapi/FromOwl.java
@@ -193,7 +193,8 @@ public class FromOwl {
                     }
 
                     if (subj != null) {
-
+                        // It is obvious that the subj is a named class, 
+                        // at this point, thus we added it into nodeTypeMap.
                         setNodeType(subj, RDFTYPES.CLASS, nodeTypeMap);
 
                         if (supc.isAnonymous()) {
@@ -225,8 +226,13 @@ public class FromOwl {
                             }
                         }
                         else {
-                            edges.add(getEdge(subj, SUBCLASS_OF, getClassId((OWLClass) supc)));
+                            // It is also obvious that the obj (supc) is a named class
+                            // at this point, thus we added it into nodeTypeMap as well.
+                            String obj = null;
+                            obj = getClassId((OWLClass) supc);
+                            setNodeType(obj, RDFTYPES.CLASS, nodeTypeMap);
 
+                            edges.add(getEdge(subj, SUBCLASS_OF, getClassId((OWLClass) supc)));
                         }
                     }
                     else {

--- a/src/main/java/org/geneontology/obographs/owlapi/FromOwl.java
+++ b/src/main/java/org/geneontology/obographs/owlapi/FromOwl.java
@@ -232,7 +232,7 @@ public class FromOwl {
                             obj = getClassId((OWLClass) supc);
                             setNodeType(obj, RDFTYPES.CLASS, nodeTypeMap);
 
-                            edges.add(getEdge(subj, SUBCLASS_OF, getClassId((OWLClass) supc)));
+                            edges.add(getEdge(subj, SUBCLASS_OF, obj));
                         }
                     }
                     else {


### PR DESCRIPTION
* As discussed in [this post](https://github.com/geneontology/obographs/issues/33), I added codes that automatically recognize objects of property rdfs:subClassOf as nodes in Obograph.
* I also revised pom.xml slightly; I recently switch to Java 9 and found that I was not able to compile Obograph using Java 9 due to some old libaries. 