### PR TITLE
Fix `RO`-derived URL error in examples

### DIFF
--- a/examples/ro.json
+++ b/examples/ro.json
@@ -8704,7 +8704,7 @@
       "meta" : {
         "definition" : {
           "val" : "Convergence that results from co-evolution usually involving an evolutionary arms race.",
-          "xrefs" : [ "http://purl.obolibrary.org/obo/HOM_0000033", "http:://en.wikipedia.org/wiki/Mimicry" ]
+          "xrefs" : [ "http://purl.obolibrary.org/obo/HOM_0000033", "http://en.wikipedia.org/wiki/Mimicry" ]
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",

--- a/examples/ro.yaml
+++ b/examples/ro.yaml
@@ -7358,7 +7358,7 @@ graphs:
           \ arms race."
         xrefs:
         - "http://purl.obolibrary.org/obo/HOM_0000033"
-        - "http:://en.wikipedia.org/wiki/Mimicry"
+        - "http://en.wikipedia.org/wiki/Mimicry"
       synonyms:
       - pred: "hasExactSynonym"
         val: "mimicrous to"


### PR DESCRIPTION
Just like [oborel/obo-relations#324](https://github.com/oborel/obo-relations/pull/324), the RO contained an invalid URL that was fixed at some point but it still present in dependent files that were not regenerated since then.