### PR TITLE
Record type semantics for Java core library, test clean-up and taming FromOwl

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,20 +16,15 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
+        cache-dependency-path: '**/pom.xml' # optional
     - name: Build with Maven
       run: mvn -B package --file pom.xml
-
-    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/examples/equivNodeSetTest.json
+++ b/examples/equivNodeSetTest.json
@@ -74,11 +74,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An angiosarcoma that arises from the soft tissues, usually in the deep muscles of the lower extremities, retroperitoneum, mediastinum, and mesentery."
+          "val" : "An angiosarcoma that arises from the soft tissues, usually in the deep muscles of the lower extremities, retroperitoneum, mediastinum, and mesentery.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "NCI"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Angiosarcoma of Soft Tissue"
+          "val" : "Angiosarcoma of Soft Tissue",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117",
+              "val" : "NCI"
+            } ]
+          }
         } ]
       }
     }, {
@@ -87,32 +99,86 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A malignant tumor arising from the endothelial cells of the blood vessels.  Microscopically, it is characterized by frequently open vascular anastomosing and branching channels.  The malignant cells that line the vascular channels are spindle or epithelioid and often display hyperchromatic nuclei.  Angiosarcomas most frequently occur in the skin and breast.  Patients with long-standing lymphedema are at increased risk of developing angiosarcoma."
+          "val" : "A malignant tumor arising from the endothelial cells of the blood vessels.  Microscopically, it is characterized by frequently open vascular anastomosing and branching channels.  The malignant cells that line the vascular channels are spindle or epithelioid and often display hyperchromatic nuclei.  Angiosarcomas most frequently occur in the skin and breast.  Patients with long-standing lymphedema are at increased risk of developing angiosarcoma.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000119",
+              "val" : "NCI"
+            } ]
+          }
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "Angiosarcoma"
+          "val" : "Angiosarcoma",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117",
+              "val" : "NCI"
+            } ]
+          }
         }, {
           "pred" : "hasExactSynonym",
-          "val" : "HEMANGIOSARCOMA, MALIGNANT"
+          "val" : "HEMANGIOSARCOMA, MALIGNANT",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117",
+              "val" : "CDISC"
+            } ]
+          }
         }, {
           "pred" : "hasExactSynonym",
-          "val" : "Hemangiosarcoma"
+          "val" : "Hemangiosarcoma",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117",
+              "val" : "CDISC"
+            } ]
+          }
         }, {
           "pred" : "hasExactSynonym",
-          "val" : "Hemangiosarcoma"
+          "val" : "Hemangiosarcoma",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117",
+              "val" : "NCI"
+            } ]
+          }
         }, {
           "pred" : "hasExactSynonym",
-          "val" : "Malignant Angioendothelioma"
+          "val" : "Malignant Angioendothelioma",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117",
+              "val" : "NCI"
+            } ]
+          }
         }, {
           "pred" : "hasExactSynonym",
-          "val" : "Malignant Hemangioendothelioma"
+          "val" : "Malignant Hemangioendothelioma",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117",
+              "val" : "NCI"
+            } ]
+          }
         }, {
           "pred" : "hasExactSynonym",
-          "val" : "angiosarcoma"
+          "val" : "angiosarcoma",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117",
+              "val" : "NCI-GLOSS"
+            } ]
+          }
         }, {
           "pred" : "hasExactSynonym",
-          "val" : "hemangiosarcoma"
+          "val" : "hemangiosarcoma",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117",
+              "val" : "NCI-GLOSS"
+            } ]
+          }
         } ]
       }
     }, {

--- a/examples/equivNodeSetTest.yaml
+++ b/examples/equivNodeSetTest.yaml
@@ -59,9 +59,17 @@ graphs:
       definition:
         val: "An angiosarcoma that arises from the soft tissues, usually in the deep\
           \ muscles of the lower extremities, retroperitoneum, mediastinum, and mesentery."
+        meta:
+          basicPropertyValues:
+          - pred: "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000119"
+            val: "NCI"
       synonyms:
       - pred: "hasExactSynonym"
         val: "Angiosarcoma of Soft Tissue"
+        meta:
+          basicPropertyValues:
+          - pred: "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117"
+            val: "NCI"
   - id: "http://purl.obolibrary.org/obo/NCIT_C3088"
     lbl: "Angiosarcoma"
     type: "CLASS"
@@ -73,23 +81,59 @@ graphs:
           \ are spindle or epithelioid and often display hyperchromatic nuclei.  Angiosarcomas\
           \ most frequently occur in the skin and breast.  Patients with long-standing\
           \ lymphedema are at increased risk of developing angiosarcoma."
+        meta:
+          basicPropertyValues:
+          - pred: "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000119"
+            val: "NCI"
       synonyms:
       - pred: "hasExactSynonym"
         val: "Angiosarcoma"
+        meta:
+          basicPropertyValues:
+          - pred: "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117"
+            val: "NCI"
       - pred: "hasExactSynonym"
         val: "HEMANGIOSARCOMA, MALIGNANT"
+        meta:
+          basicPropertyValues:
+          - pred: "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117"
+            val: "CDISC"
       - pred: "hasExactSynonym"
         val: "Hemangiosarcoma"
+        meta:
+          basicPropertyValues:
+          - pred: "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117"
+            val: "CDISC"
       - pred: "hasExactSynonym"
         val: "Hemangiosarcoma"
+        meta:
+          basicPropertyValues:
+          - pred: "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117"
+            val: "NCI"
       - pred: "hasExactSynonym"
         val: "Malignant Angioendothelioma"
+        meta:
+          basicPropertyValues:
+          - pred: "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117"
+            val: "NCI"
       - pred: "hasExactSynonym"
         val: "Malignant Hemangioendothelioma"
+        meta:
+          basicPropertyValues:
+          - pred: "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117"
+            val: "NCI"
       - pred: "hasExactSynonym"
         val: "angiosarcoma"
+        meta:
+          basicPropertyValues:
+          - pred: "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117"
+            val: "NCI-GLOSS"
       - pred: "hasExactSynonym"
         val: "hemangiosarcoma"
+        meta:
+          basicPropertyValues:
+          - pred: "http://www.geneontology.org/formats/oboInOwl#http://purl.obolibrary.org/obo/IAO_0000117"
+            val: "NCI-GLOSS"
   - id: "http://purl.obolibrary.org/obo/Orphanet_263413"
     lbl: "Angiosarcoma"
     type: "CLASS"

--- a/examples/ro.json
+++ b/examples/ro.json
@@ -3257,7 +3257,13 @@
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "A caterpillar walking on the surface of a leaf is adjacent_to the leaf, if one of the caterpillar appendages is touching the leaf. In contrast, a butterfly flying close to a flower is not considered adjacent, unless there are any touching parts."
+          "val" : "A caterpillar walking on the surface of a leaf is adjacent_to the leaf, if one of the caterpillar appendages is touching the leaf. In contrast, a butterfly flying close to a flower is not considered adjacent, unless there are any touching parts.",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+              "val" : "https://github.com/jhpoelen/eol-globi-data/issues/225#issuecomment-218584934"
+            } ]
+          }
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
           "val" : "The epidermis layer of a vertebrate is adjacent to the dermis."
@@ -5799,10 +5805,10 @@
         } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "Considering relabeling as 'pairwise interacts with'"
+          "val" : "This relation and all sub-relations can be applied to either (1) pairs of entities that are interacting at any moment of time (2) populations or species of entity whose members have the disposition to interact (3) classes whose members have the disposition to interact."
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "This relation and all sub-relations can be applied to either (1) pairs of entities that are interacting at any moment of time (2) populations or species of entity whose members have the disposition to interact (3) classes whose members have the disposition to interact."
+          "val" : "Considering relabeling as 'pairwise interacts with'"
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "Chris Mungall"
@@ -8071,7 +8077,13 @@
           "val" : "pazopanib -> pathological angiogenesis"
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
-          "val" : "treats"
+          "val" : "treats",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+              "val" : "Usage of the term 'treats' applies when we believe there to be a an inhibitory relationship"
+            } ]
+          }
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
           "val" : "http://purl.obolibrary.org/obo/ro/docs/causal-relations"
@@ -11432,7 +11444,13 @@
       "meta" : {
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000589",
-          "val" : "is defined by"
+          "val" : "is defined by",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+              "val" : "This is an experimental annotation"
+            } ]
+          }
         } ]
       }
     } ],

--- a/examples/ro.yaml
+++ b/examples/ro.yaml
@@ -2878,6 +2878,10 @@ graphs:
           \ if one of the caterpillar appendages is touching the leaf. In contrast,\
           \ a butterfly flying close to a flower is not considered adjacent, unless\
           \ there are any touching parts."
+        meta:
+          basicPropertyValues:
+          - pred: "http://www.w3.org/2000/01/rdf-schema#seeAlso"
+            val: "https://github.com/jhpoelen/eol-globi-data/issues/225#issuecomment-218584934"
       - pred: "http://purl.obolibrary.org/obo/IAO_0000112"
         val: "The epidermis layer of a vertebrate is adjacent to the dermis."
       - pred: "http://purl.obolibrary.org/obo/IAO_0000112"
@@ -4992,12 +4996,12 @@ graphs:
         val: "in pairwise interaction with"
       basicPropertyValues:
       - pred: "http://purl.obolibrary.org/obo/IAO_0000116"
-        val: "Considering relabeling as 'pairwise interacts with'"
-      - pred: "http://purl.obolibrary.org/obo/IAO_0000116"
         val: "This relation and all sub-relations can be applied to either (1) pairs\
           \ of entities that are interacting at any moment of time (2) populations\
           \ or species of entity whose members have the disposition to interact (3)\
           \ classes whose members have the disposition to interact."
+      - pred: "http://purl.obolibrary.org/obo/IAO_0000116"
+        val: "Considering relabeling as 'pairwise interacts with'"
       - pred: "http://purl.obolibrary.org/obo/IAO_0000117"
         val: "Chris Mungall"
       - pred: "http://purl.obolibrary.org/obo/IAO_0000232"
@@ -6874,6 +6878,11 @@ graphs:
         val: "pazopanib -> pathological angiogenesis"
       - pred: "http://purl.obolibrary.org/obo/IAO_0000118"
         val: "treats"
+        meta:
+          basicPropertyValues:
+          - pred: "http://www.w3.org/2000/01/rdf-schema#comment"
+            val: "Usage of the term 'treats' applies when we believe there to be a\
+              \ an inhibitory relationship"
       - pred: "http://purl.obolibrary.org/obo/IAO_0000119"
         val: "http://purl.obolibrary.org/obo/ro/docs/causal-relations"
       - pred: "http://purl.obolibrary.org/obo/IAO_0000232"
@@ -9760,6 +9769,10 @@ graphs:
       basicPropertyValues:
       - pred: "http://purl.obolibrary.org/obo/IAO_0000589"
         val: "is defined by"
+        meta:
+          basicPropertyValues:
+          - pred: "http://www.w3.org/2000/01/rdf-schema#comment"
+            val: "This is an experimental annotation"
   edges:
   - sub: "http://purl.obolibrary.org/obo/BFO_0000004"
     pred: "is_a"

--- a/obographs-cli/pom.xml
+++ b/obographs-cli/pom.xml
@@ -5,16 +5,11 @@
     <parent>
         <artifactId>obographs</artifactId>
         <groupId>org.geneontology.obographs</groupId>
-        <version>0.3.1</version>
+        <version>0.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>obographs-cli</artifactId>
-
-    <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-    </properties>
 
     <dependencies>
         <dependency>
@@ -35,17 +30,14 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.4.7</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.7</version>
         </dependency>
     </dependencies>
 

--- a/obographs-cli/src/main/java/org/geneontology/obographs/cli/commands/Convert.java
+++ b/obographs-cli/src/main/java/org/geneontology/obographs/cli/commands/Convert.java
@@ -62,11 +62,10 @@ public class Convert implements Callable<Integer> {
                 GraphDocument graphDocument = fromOwl.generateGraphDocument(owlOntology);
                 for (Format format : formats) {
                     Path outFile = outFile(inputFile, format);
-                    if (format == Format.json) {
-                        OgJsonGenerator.write(outFile.toFile(), graphDocument);
-                    }
-                    if (format == Format.yaml) {
-                        OgYamlGenerator.write(outFile.toFile(), graphDocument);
+                    switch (format) {
+                        case json -> OgJsonGenerator.write(outFile.toFile(), graphDocument);
+                        case yaml -> OgYamlGenerator.write(outFile.toFile(), graphDocument);
+                        default -> throw new IllegalStateException("Unexpected format value: " + format);
                     }
                     System.err.println("Written " + outFile.toAbsolutePath());
                 }

--- a/obographs-cli/src/main/java/org/geneontology/obographs/cli/commands/Validate.java
+++ b/obographs-cli/src/main/java/org/geneontology/obographs/cli/commands/Validate.java
@@ -25,16 +25,17 @@ public class Validate implements Callable<Integer> {
             try {
                 var fileType = detectFileType(inputFile);
                 System.err.print(inputFile);
-                if ("json".equals(fileType)) {
-                    OgJsonReader.readFile(inputFile.toFile());
-                    System.err.print(" - OK\n");
-                } else if ("yaml".equals(fileType)) {
-                    OgYamlReader.readFile(inputFile.toFile());
-                    System.err.print(" - OK\n");
-                } else if ("dir".equals(fileType)) {
-                    System.err.println(" - is directory");
-                } else {
-                    System.err.println(" - invalid file type");
+                switch (fileType) {
+                    case "json" -> {
+                        OgJsonReader.readFile(inputFile.toFile());
+                        System.err.print(" - OK\n");
+                    }
+                    case "yaml" -> {
+                        OgYamlReader.readFile(inputFile.toFile());
+                        System.err.print(" - OK\n");
+                    }
+                    case "dir" -> System.err.println(" - is directory");
+                    default -> System.err.println(" - invalid file type");
                 }
             } catch (Exception e) {
                 System.err.print(" - ERROR: ");

--- a/obographs-core/pom.xml
+++ b/obographs-core/pom.xml
@@ -5,22 +5,17 @@
     <parent>
         <groupId>org.geneontology.obographs</groupId>
         <artifactId>obographs</artifactId>
-        <version>0.3.1</version>
+        <version>0.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>obographs-core</artifactId>
 
-    <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
-            <version>2.10.0</version>
+            <version>2.10.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -43,7 +38,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.14.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/io/OgYamlReader.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/io/OgYamlReader.java
@@ -1,8 +1,11 @@
 package org.geneontology.obographs.core.io;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder;
 import org.geneontology.obographs.core.model.GraphDocument;
+import org.yaml.snakeyaml.LoaderOptions;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,6 +24,7 @@ public class OgYamlReader {
 
 	public static GraphDocument readFile(File file) throws IOException {
 		ObjectMapper objectMapper = newObjectMapper();
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 		return objectMapper.readValue(file, GraphDocument.class);
 	}
 
@@ -35,6 +39,10 @@ public class OgYamlReader {
 	}
 
 	private static ObjectMapper newObjectMapper() {
-		return new ObjectMapper(new YAMLFactory());
+		// This needs to be set way above the default of 3 * 1024 * 1024; (3 MB) as hp.yaml is too large with the
+		// addition of the BasicPropertyValueMeta
+		LoaderOptions loaderOptions = new LoaderOptions();
+		loaderOptions.setCodePointLimit(100 * 1024 * 1024); // 100MB
+		return new ObjectMapper(new YAMLFactoryBuilder(new YAMLFactory()).loaderOptions(loaderOptions).build());
 	}
 }

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/AbstractEdge.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/AbstractEdge.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.immutables.value.Value;
 
+import javax.annotation.Nullable;
 import java.util.Comparator;
 
 /**
@@ -16,19 +17,24 @@ import java.util.Comparator;
 public abstract class AbstractEdge implements NodeOrEdge, Comparable<AbstractEdge> {
 
     private static final Comparator<AbstractEdge> COMPARATOR =
-            Comparator.comparing(AbstractEdge::getSub)
-                    .thenComparing(AbstractEdge::getPred)
-                    .thenComparing(AbstractEdge::getObj);
+            Comparator.comparing(AbstractEdge::sub)
+                    .thenComparing(AbstractEdge::pred)
+                    .thenComparing(AbstractEdge::obj);
 
     @JsonProperty
-    public abstract String getSub();
+    public abstract String sub();
 
     @JsonProperty
-    public abstract String getPred();
+    public abstract String pred();
 
     @JsonProperty
-    public abstract String getObj();
+    public abstract String obj();
 
+    @JsonProperty
+    @Nullable
+    public abstract Meta meta();
+
+    @Override
     public int compareTo(AbstractEdge other) {
         return COMPARATOR.compare(this, other);
     }

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/AbstractGraph.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/AbstractGraph.java
@@ -46,7 +46,7 @@ public abstract class AbstractGraph {
      */
     @JsonProperty
     @Value.Default
-    public String getId() {
+    public String id() {
         return "";
     }
 
@@ -55,7 +55,7 @@ public abstract class AbstractGraph {
      */
     @JsonProperty
     @Value.Default
-    public String getLbl() {
+    public String lbl() {
         return "";
     }
 
@@ -64,42 +64,42 @@ public abstract class AbstractGraph {
      */
     @JsonProperty
     @Nullable
-    public abstract Meta getMeta();
+    public abstract Meta meta();
 
     /**
      * @return the nodes
      */
     @JsonProperty
-    public abstract List<Node> getNodes();
+    public abstract List<Node> nodes();
 
     /**
      * @return the edges
      */
     @JsonProperty
-    public abstract List<Edge> getEdges();
+    public abstract List<Edge> edges();
 
     /**
      * @return the equivalentNodesSet
      */
     @JsonProperty
-    public abstract List<EquivalentNodesSet> getEquivalentNodesSets();
+    public abstract List<EquivalentNodesSet> equivalentNodesSets();
 
     /**
      * @return the logicalDefinitionAxioms
      */
     @JsonProperty
-    public abstract List<LogicalDefinitionAxiom> getLogicalDefinitionAxioms();
+    public abstract List<LogicalDefinitionAxiom> logicalDefinitionAxioms();
 
     /**
      * @return the domainRangeAxioms
      */
     @JsonProperty
-    public abstract List<DomainRangeAxiom> getDomainRangeAxioms();
+    public abstract List<DomainRangeAxiom> domainRangeAxioms();
 
     /**
      * @return the propertyChainAxioms
      */
     @JsonProperty
-    public abstract List<PropertyChainAxiom> getPropertyChainAxioms();
+    public abstract List<PropertyChainAxiom> propertyChainAxioms();
 
 }

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/AbstractGraphDocument.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/AbstractGraphDocument.java
@@ -40,19 +40,19 @@ public abstract class AbstractGraphDocument {
      */
     @JsonProperty("@context")
     @Nullable
-    public abstract Object getContext();
+    public abstract Object context();
 
     /**
      * @return the meta
      */
     @JsonProperty
     @Nullable
-    public abstract Meta getMeta() ;
+    public abstract Meta meta() ;
 
     /**
      * @return the graphs
      */
     @JsonProperty
-    public abstract List<Graph> getGraphs();
+    public abstract List<Graph> graphs();
 
 }

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/AbstractMeta.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/AbstractMeta.java
@@ -35,38 +35,38 @@ public abstract class AbstractMeta {
 
     @JsonProperty
     @Nullable
-    public abstract DefinitionPropertyValue getDefinition();
+    public abstract DefinitionPropertyValue definition();
 
     @JsonProperty
-    public abstract List<String> getComments();
+    public abstract List<String> comments();
 
     @JsonProperty
-    public abstract List<String> getSubsets();
+    public abstract List<String> subsets();
 
     @JsonProperty
-    public abstract List<SynonymPropertyValue> getSynonyms();
+    public abstract List<SynonymPropertyValue> synonyms();
 
     @JsonProperty
-    public abstract List<XrefPropertyValue> getXrefs();
+    public abstract List<XrefPropertyValue> xrefs();
 
     @JsonIgnore
     @Value.Default
-    public List<String> getXrefsValues() {
-        return getXrefs().stream().map(XrefPropertyValue::getVal).collect(Collectors.toList());
+    public List<String> xrefsValues() {
+        return xrefs().stream().map(XrefPropertyValue::val).toList();
     }
 
     @JsonProperty
-    public abstract List<BasicPropertyValue> getBasicPropertyValues();
+    public abstract List<BasicPropertyValue> basicPropertyValues();
 
     @JsonProperty
     @Value.Default
-    public String getVersion(){
+    public String version(){
         return "";
     }
 
     @JsonProperty
     @Value.Default
-    public boolean getDeprecated() {
+    public boolean isDeprecated() {
         return false;
     }
 

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/AbstractNode.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/AbstractNode.java
@@ -32,34 +32,30 @@ import static java.util.Comparator.nullsLast;
 public abstract class AbstractNode implements NodeOrEdge, Comparable<AbstractNode> {
 
     private static final Comparator<AbstractNode> COMPARATOR =
-            Comparator.comparing(AbstractNode::getId)
-                    .thenComparing(AbstractNode::getLabel)
-                    .thenComparing(AbstractNode::getType, nullsLast(naturalOrder()))
-                    .thenComparing(AbstractNode::getPropertyType, nullsLast(naturalOrder()));
-
-    public enum RDFTYPES {CLASS, INDIVIDUAL, PROPERTY}
-
-    public enum PropertyType {ANNOTATION, OBJECT, DATA}
+            Comparator.comparing(AbstractNode::id)
+                    .thenComparing(AbstractNode::label)
+                    .thenComparing(AbstractNode::rdfType, nullsLast(naturalOrder()))
+                    .thenComparing(AbstractNode::propertyType, nullsLast(naturalOrder()));
 
     @JsonProperty
     @Value.Default
-    public String getId() {
+    public String id() {
         return "";
     }
 
     @JsonProperty("lbl")
     @Value.Default
-    public String getLabel() {
+    public String label() {
         return "";
     }
 
-    @JsonProperty
+    @JsonProperty("type")
     @Nullable
-    public abstract RDFTYPES getType();
+    public abstract RdfType rdfType();
 
     @JsonProperty
     @Nullable
-    public abstract PropertyType getPropertyType();
+    public abstract PropertyType propertyType();
 
     @Override
     public int compareTo(AbstractNode other) {

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/NodeOrEdge.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/NodeOrEdge.java
@@ -15,5 +15,5 @@ public interface NodeOrEdge {
      */
     @JsonProperty
     @Nullable
-    public Meta getMeta();
+    public Meta meta();
 }

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/PropertyType.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/PropertyType.java
@@ -1,0 +1,5 @@
+package org.geneontology.obographs.core.model;
+
+public enum PropertyType {
+    ANNOTATION, OBJECT, DATA
+}

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/RdfType.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/RdfType.java
@@ -1,0 +1,5 @@
+package org.geneontology.obographs.core.model;
+
+public enum RdfType {
+    CLASS, INDIVIDUAL, PROPERTY
+}

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/axiom/AbstractDomainRangeAxiom.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/axiom/AbstractDomainRangeAxiom.java
@@ -18,13 +18,13 @@ import java.util.Set;
 public abstract class AbstractDomainRangeAxiom implements Axiom, Comparable<AbstractDomainRangeAxiom> {
 
     private static final Comparator<AbstractDomainRangeAxiom> COMPARATOR =
-            Comparator.comparing(AbstractDomainRangeAxiom::getPredicateId);
+            Comparator.comparing(AbstractDomainRangeAxiom::predicateId);
 
     /**
      * @return the predicateId
      */
     @JsonProperty
-    public abstract String getPredicateId();
+    public abstract String predicateId();
 
     /**
      * For multiple domains, this is treated as intersection
@@ -33,7 +33,7 @@ public abstract class AbstractDomainRangeAxiom implements Axiom, Comparable<Abst
      */
     @JsonProperty
 //    @Value.NaturalOrder
-    public abstract Set<String> getDomainClassIds();
+    public abstract Set<String> domainClassIds();
 
     /**
      * For multiple ranges, this is treated as intersection
@@ -42,7 +42,7 @@ public abstract class AbstractDomainRangeAxiom implements Axiom, Comparable<Abst
      */
     @JsonProperty
 //    @Value.NaturalOrder
-    public abstract Set<String> getRangeClassIds();
+    public abstract Set<String> rangeClassIds();
 
     /**
      * Set of edges representing `X SubClassOf P only Y` axioms.
@@ -55,7 +55,7 @@ public abstract class AbstractDomainRangeAxiom implements Axiom, Comparable<Abst
      */
     @JsonProperty
 //    @Value.NaturalOrder
-    public abstract Set<Edge> getAllValuesFromEdges();
+    public abstract Set<Edge> allValuesFromEdges();
 
     @Override
     public int compareTo(AbstractDomainRangeAxiom o) {

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/axiom/AbstractEquivalentNodesSet.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/axiom/AbstractEquivalentNodesSet.java
@@ -21,15 +21,15 @@ import java.util.Set;
 public abstract class AbstractEquivalentNodesSet implements Axiom, Comparable<AbstractEquivalentNodesSet> {
 
     private static final Comparator<AbstractEquivalentNodesSet> COMPARATOR =
-            Comparator.comparing(AbstractEquivalentNodesSet::getRepresentativeNodeId);
+            Comparator.comparing(AbstractEquivalentNodesSet::representativeNodeId);
 
     /**
      * @return the representativeNodeId
      */
     @JsonProperty
     @Value.Default
-    public String getRepresentativeNodeId() {
-        String representative = getNodeIds().iterator().next();
+    public String representativeNodeId() {
+        String representative = nodeIds().iterator().next();
         return representative == null ? "" : representative;
     }
 
@@ -38,7 +38,7 @@ public abstract class AbstractEquivalentNodesSet implements Axiom, Comparable<Ab
      */
     @JsonProperty
 //    @Value.NaturalOrder
-    public abstract Set<String> getNodeIds();
+    public abstract Set<String> nodeIds();
 
     @Override
     public int compareTo(AbstractEquivalentNodesSet o) {

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/axiom/AbstractExistentialRestrictionExpression.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/axiom/AbstractExistentialRestrictionExpression.java
@@ -19,19 +19,19 @@ import java.util.Comparator;
 public abstract class AbstractExistentialRestrictionExpression implements Expression, Comparable<AbstractExistentialRestrictionExpression> {
 
     private static final Comparator<AbstractExistentialRestrictionExpression> COMPARATOR =
-            Comparator.comparing(AbstractExistentialRestrictionExpression::getPropertyId)
-                    .thenComparing(AbstractExistentialRestrictionExpression::getFillerId);
+            Comparator.comparing(AbstractExistentialRestrictionExpression::propertyId)
+                    .thenComparing(AbstractExistentialRestrictionExpression::fillerId);
     /**
      * @return the propertyId
      */
     @JsonProperty
-    public abstract String getPropertyId();
+    public abstract String propertyId();
 
     /**
      * @return the representativeNodeId
      */
     @JsonProperty
-    public abstract String getFillerId();
+    public abstract String fillerId();
 
     @Override
     public int compareTo(AbstractExistentialRestrictionExpression o) {

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/axiom/AbstractLogicalDefinitionAxiom.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/axiom/AbstractLogicalDefinitionAxiom.java
@@ -20,25 +20,25 @@ import java.util.List;
 public abstract class AbstractLogicalDefinitionAxiom implements Axiom, Comparable<AbstractLogicalDefinitionAxiom> {
 
     private static final Comparator<AbstractLogicalDefinitionAxiom> COMPARATOR =
-            Comparator.comparing(AbstractLogicalDefinitionAxiom::getDefinedClassId);
+            Comparator.comparing(AbstractLogicalDefinitionAxiom::definedClassId);
 
     /**
      * @return the representativeNodeId
      */
     @JsonProperty
-    public abstract String getDefinedClassId();
+    public abstract String definedClassId();
 
     /**
      * @return the nodeIds
      */
     @JsonProperty
-    public abstract List<String> getGenusIds();
+    public abstract List<String> genusIds();
 
     /**
      * @return the restrictions
      */
     @JsonProperty
-    public abstract List<ExistentialRestrictionExpression> getRestrictions();
+    public abstract List<ExistentialRestrictionExpression> restrictions();
 
     @Override
     public int compareTo(AbstractLogicalDefinitionAxiom o) {

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/axiom/AbstractPropertyChainAxiom.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/axiom/AbstractPropertyChainAxiom.java
@@ -20,19 +20,19 @@ public abstract class AbstractPropertyChainAxiom implements Axiom, Comparable<Ab
 
 
     private static final Comparator<AbstractPropertyChainAxiom> COMPARATOR =
-            Comparator.comparing(AbstractPropertyChainAxiom::getPredicateId);
+            Comparator.comparing(AbstractPropertyChainAxiom::predicateId);
 
     /**
      * @return the predicateId
      */
     @JsonProperty
-    public abstract String getPredicateId();
+    public abstract String predicateId();
     
     /**
      * @return the chainPredicateIds
      */
     @JsonProperty
-    public abstract List<String> getChainPredicateIds();
+    public abstract List<String> chainPredicateIds();
 
     @Override
     public int compareTo(AbstractPropertyChainAxiom o) {

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/axiom/Axiom.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/axiom/Axiom.java
@@ -14,5 +14,5 @@ public interface Axiom {
      */
     @JsonProperty
     @Nullable
-    public Meta getMeta();
+    public Meta meta();
 }

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/meta/AbstractSynonymPropertyValue.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/meta/AbstractSynonymPropertyValue.java
@@ -23,32 +23,25 @@ public abstract class AbstractSynonymPropertyValue implements PropertyValue {
      *
      * @author cjm
      */
-    public enum SCOPES {
+    public enum Scope {
         EXACT,
         NARROW,
         BROAD,
         RELATED;
 
-        //TODO: use this as an enum or remove it and just use the pred()
         public String pred() {
-            switch (this) {
-                case EXACT:
-                    return "hasExactSynonym";
-                case RELATED:
-                    return "hasRelatedSynonym";
-                case BROAD:
-                    return "hasBroadSynonym";
-                case NARROW:
-                    return "hasNarrowSynonym";
-                default:
-                    return "hasRelatedSynonym";
-            }
+            return switch (this) {
+                case EXACT -> "hasExactSynonym";
+                case NARROW -> "hasNarrowSynonym";
+                case BROAD -> "hasBroadSynonym";
+                case RELATED -> "hasRelatedSynonym";
+            };
         }
     }
 
     @JsonProperty
     @Value.Default
-    public String getSynonymType() {
+    public String synonymType() {
         return "";
     }
 
@@ -57,38 +50,29 @@ public abstract class AbstractSynonymPropertyValue implements PropertyValue {
      */
     @JsonIgnore
     public boolean isExact() {
-        return getPred().equals("hasExactSynonym");
+        return Scope.EXACT.pred().equals(pred());
     }
 
     @JsonIgnore
     public boolean isRelated() {
-        return getPred().equals("hasRelatedSynonym");
+        return Scope.RELATED.pred().equals(pred());
     }
 
     @JsonIgnore
     public boolean isBroad() {
-        return getPred().equals("hasBroadSynonym");
+        return Scope.BROAD.pred().equals(pred());
     }
 
     @JsonIgnore
     public boolean isNarrow() {
-        return getPred().equals("hasNarrowSynonym");
+        return Scope.NARROW.pred().equals(pred());
     }
 
     @JsonIgnore
-    public List<String> getTypes() {
-        if (getMeta() != null) {
-            return getMeta().getSubsets();
+    public List<String> types() {
+        if (meta() != null) {
+            return meta().subsets();
         }
         return Collections.emptyList();
     }
-
-    // n.b. this was never used in any production code. Left it here for audit purposed, but this should be handled by
-    // the FromOwl class adding to the SynonymPropertyValue.Meta.
-//        public Builder addType(String type) {
-//            // TODO: decide on pattern for nested builders
-//            super.meta(new Meta.Builder().subsets(Collections.singletonList(type)).build());
-//            return this;
-//        }
-
 }

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/meta/AbstractXrefPropertyValue.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/meta/AbstractXrefPropertyValue.java
@@ -14,7 +14,7 @@ public abstract class AbstractXrefPropertyValue implements PropertyValue {
      */
     @JsonProperty
     @Value.Default
-    public String getLbl() {
+    public String lbl() {
         return "";
     }
 

--- a/obographs-core/src/main/java/org/geneontology/obographs/core/model/meta/PropertyValue.java
+++ b/obographs-core/src/main/java/org/geneontology/obographs/core/model/meta/PropertyValue.java
@@ -35,8 +35,8 @@ import java.util.List;
 public interface PropertyValue extends Comparable<PropertyValue> {
 
     static final Comparator<PropertyValue> COMPARATOR =
-       Comparator.comparing(PropertyValue::getPred)
-            .thenComparing(PropertyValue::getVal);
+       Comparator.comparing(PropertyValue::pred)
+            .thenComparing(PropertyValue::val);
 
     /**
      * Predicates correspond to OWL properties. Like all preds in this datamodel,
@@ -46,7 +46,7 @@ public interface PropertyValue extends Comparable<PropertyValue> {
      */
     @JsonProperty
     @Value.Default
-    default String getPred() {
+    default String pred() {
         return "";
     }
 
@@ -57,7 +57,7 @@ public interface PropertyValue extends Comparable<PropertyValue> {
      */
     @JsonProperty
     @Value.Default
-    default String getVal() {
+    default String val() {
         return "";
     }
 
@@ -67,11 +67,11 @@ public interface PropertyValue extends Comparable<PropertyValue> {
      * @return the xrefs
      */
     @JsonProperty
-    public List<String> getXrefs();
+    public List<String> xrefs();
 
     @JsonProperty
     @Nullable
-    public Meta getMeta();
+    public Meta meta();
 
     @Override
     default int compareTo(PropertyValue o) {

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/io/OgJsonGeneratorTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/io/OgJsonGeneratorTest.java
@@ -36,39 +36,39 @@ public class OgJsonGeneratorTest {
 
         assertEquals(testGraphDocument, graphDocument);
 
-        assertEquals(1, graphDocument.getGraphs().size());
-        Graph graph = graphDocument.getGraphs().get(0);
-        assertEquals(2, graph.getNodes().size());
+        assertEquals(1, graphDocument.graphs().size());
+        Graph graph = graphDocument.graphs().get(0);
+        assertEquals(2, graph.nodes().size());
 
-        Node node1 = graph.getNodes().get(0);
-        assertEquals("GO:0005634", node1.getId());
-        assertEquals("nucleus", node1.getLabel());
-        Meta node1Meta = node1.getMeta();
+        Node node1 = graph.nodes().get(0);
+        assertEquals("GO:0005634", node1.id());
+        assertEquals("nucleus", node1.label());
+        Meta node1Meta = node1.meta();
         assertEquals("A membrane-bounded organelle of eukaryotic cells in which chromosomes are housed and " +
                 "replicated. In most cells, the nucleus contains all of the cell's chromosomes except the organellar " +
                 "chromosomes, and is the site of RNA synthesis and processing. In some species, or in specialized cell" +
-                " types, RNA metabolism or DNA replication may be absent.", node1Meta.getDefinition().getVal());
-        assertEquals(Arrays.asList("GOC:go_curators"), node1Meta.getDefinition().getXrefs());
-        assertEquals(Arrays.asList("goslim_yeast", "goslim_plant"), node1Meta.getSubsets());
+                " types, RNA metabolism or DNA replication may be absent.", node1Meta.definition().val());
+        assertEquals(Arrays.asList("GOC:go_curators"), node1Meta.definition().xrefs());
+        assertEquals(Arrays.asList("goslim_yeast", "goslim_plant"), node1Meta.subsets());
 
-        XrefPropertyValue xrefPropertyValue = node1Meta.getXrefs().get(0);
-        assertEquals("ICD10:111", xrefPropertyValue.getVal());
-        assertEquals("foo disease", xrefPropertyValue.getLbl());
+        XrefPropertyValue xrefPropertyValue = node1Meta.xrefs().get(0);
+        assertEquals("ICD10:111", xrefPropertyValue.val());
+        assertEquals("foo disease", xrefPropertyValue.lbl());
 
-        SynonymPropertyValue synonymPropertyValue = node1Meta.getSynonyms().get(0);
-        assertEquals("cell nucleus", synonymPropertyValue.getVal());
-        assertEquals("hasExactSynonym", synonymPropertyValue.getPred());
-        assertEquals(Arrays.asList("GOC:go_curators"), synonymPropertyValue.getXrefs());
+        SynonymPropertyValue synonymPropertyValue = node1Meta.synonyms().get(0);
+        assertEquals("cell nucleus", synonymPropertyValue.val());
+        assertEquals("hasExactSynonym", synonymPropertyValue.pred());
+        assertEquals(Arrays.asList("GOC:go_curators"), synonymPropertyValue.xrefs());
 
-        Node node2 = graph.getNodes().get(1);
-        assertEquals("GO:0005623", node2.getId());
-        assertEquals("cell", node2.getLabel());
+        Node node2 = graph.nodes().get(1);
+        assertEquals("GO:0005623", node2.id());
+        assertEquals("cell", node2.label());
 
-        assertEquals(1, graph.getEdges().size());
-        Edge edge = graph.getEdges().get(0);
-        assertEquals("GO:0005634", edge.getSub());
-        assertEquals("part_of", edge.getPred());
-        assertEquals("GO:0005623", edge.getObj());
+        assertEquals(1, graph.edges().size());
+        Edge edge = graph.edges().get(0);
+        assertEquals("GO:0005634", edge.sub());
+        assertEquals("part_of", edge.pred());
+        assertEquals("GO:0005623", edge.obj());
     }
 
 }

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/io/OgJsonReaderTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/io/OgJsonReaderTest.java
@@ -24,7 +24,7 @@ public class OgJsonReaderTest {
         GraphDocument graphDocument = OgJsonReader.readFile(ontologyPath.toFile());
         Instant end = Instant.now();
         System.out.printf("Read %s in %dms%n", ontologyPath, Duration.between(start, end).toMillis());
-        Node node = graphDocument.getGraphs().get(0).getNodes().get(0);
+        Node node = graphDocument.graphs().get(0).nodes().get(0);
         System.out.println(node);
         System.out.println(OgJsonGenerator.render(node));
     }
@@ -36,7 +36,7 @@ public class OgJsonReaderTest {
         GraphDocument graphDocument = OgJsonReader.readInputStream(Files.newInputStream(ontologyPath));
         Instant end = Instant.now();
         System.out.printf("Read %s in %dms%n", ontologyPath, Duration.between(start, end).toMillis());
-        Node node = graphDocument.getGraphs().get(0).getNodes().get(0);
+        Node node = graphDocument.graphs().get(0).nodes().get(0);
         System.out.println(node);
         System.out.println(OgJsonGenerator.render(node));
     }
@@ -48,7 +48,7 @@ public class OgJsonReaderTest {
         GraphDocument graphDocument = OgJsonReader.read(Files.newBufferedReader(ontologyPath, StandardCharsets.UTF_8));
         Instant end = Instant.now();
         System.out.printf("Read %s in %dms%n", ontologyPath, Duration.between(start, end).toMillis());
-        Node node = graphDocument.getGraphs().get(0).getNodes().get(0);
+        Node node = graphDocument.graphs().get(0).nodes().get(0);
         System.out.println(node);
         System.out.println(OgJsonGenerator.render(node));
     }

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/model/EdgeTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/model/EdgeTest.java
@@ -9,11 +9,11 @@ public class EdgeTest {
 	static String pred = "part_of";
 
 	@Test
-	public void test() {
+	void test() {
 		Edge e = build();
-		assertEquals(NodeTest.id, e.getSub());
-		assertEquals(pred, e.getPred());
-		assertEquals(NodeTest.parent_id, e.getObj());
+		assertEquals(NodeTest.id, e.sub());
+		assertEquals(pred, e.pred());
+		assertEquals(NodeTest.parent_id, e.obj());
 	}
 	
 	public static Edge build() {

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/model/GraphDocumentTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/model/GraphDocumentTest.java
@@ -17,10 +17,10 @@ public class GraphDocumentTest {
     @Test
     public void test() throws JsonProcessingException {
         GraphDocument d = build();
-        Graph g = d.getGraphs().get(0);
-        assertEquals(2, g.getNodes().size());
-        assertEquals(1, g.getEdges().size());
-        assertEquals(1, d.getGraphs().size());
+        Graph g = d.graphs().get(0);
+        assertEquals(2, g.nodes().size());
+        assertEquals(1, g.edges().size());
+        assertEquals(1, d.graphs().size());
 
         System.out.println(OgJsonGenerator.render(d));
         System.out.println(OgYamlGenerator.render(d));
@@ -28,15 +28,14 @@ public class GraphDocumentTest {
     
     public static GraphDocument build() {
         Graph g = GraphTest.build();
-        List<Graph> graphs =  (List<Graph>) Collections.singletonList(g);
+        List<Graph> graphs = List.of(g);
 
-        Map<Object,Object> context = new HashMap<>();
-        context.put("GO", "http://purl.obolibrary.org/obo/GO_");
+        Map<Object,Object> context = Map.of("GO", "http://purl.obolibrary.org/obo/GO_");
 
-        GraphDocument d = new GraphDocument.Builder().
-                context(context).
-                graphs(graphs).build();
-        return d;
+        return new GraphDocument.Builder()
+                .context(context)
+                .graphs(graphs)
+                .build();
     }
 
 

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/model/GraphTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/model/GraphTest.java
@@ -5,8 +5,6 @@ import org.geneontology.obographs.core.io.OgJsonGenerator;
 import org.geneontology.obographs.core.io.OgYamlGenerator;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,8 +14,8 @@ public class GraphTest {
 	@Test
 	public void test() throws JsonProcessingException {
 	    Graph g = build();
-		assertEquals(2, g.getNodes().size());
-		assertEquals(1, g.getEdges().size());
+		assertEquals(2, g.nodes().size());
+		assertEquals(1, g.edges().size());
 		
 		System.out.println(OgJsonGenerator.render(g));
 		System.out.println(OgYamlGenerator.render(g));
@@ -28,12 +26,9 @@ public class GraphTest {
         Node p = NodeTest.buildParent();
         Edge e = EdgeTest.build();
         
-        List<Node> nodes = new ArrayList<>();
-        nodes.add(n);
-        nodes.add(p);
-        List<Edge> edges = (List<Edge>) Collections.singletonList(e);
-        Graph g = new Graph.Builder().nodes(nodes).edges(edges).build();
-	    return g;
+        List<Node> nodes = List.of(n, p);
+        List<Edge> edges = List.of(e);
+		return new Graph.Builder().nodes(nodes).edges(edges).build();
 	}
 	
 	

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/model/MetaTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/model/MetaTest.java
@@ -3,8 +3,7 @@ package org.geneontology.obographs.core.model;
 import org.geneontology.obographs.core.model.meta.*;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -23,13 +22,13 @@ public class MetaTest {
     }
 
     public static void testMeta(Meta m) {
-        assertEquals(defval, m.getDefinition().getVal());       
-        assertEquals(1, m.getDefinition().getXrefs().size());       
-        assertEquals(2, m.getSubsets().size());   
-        assertEquals(1, m.getXrefs().size());   
-        assertEquals(XrefPropertyValueTest.val, m.getXrefs().get(0).getVal());
-        assertEquals(XrefPropertyValueTest.lbl, m.getXrefs().get(0).getLbl());
-        assertFalse(m.getDeprecated());
+        assertEquals(defval, m.definition().val());
+        assertEquals(1, m.definition().xrefs().size());
+        assertEquals(2, m.subsets().size());
+        assertEquals(1, m.xrefs().size());
+        assertEquals(XrefPropertyValueTest.val, m.xrefs().get(0).val());
+        assertEquals(XrefPropertyValueTest.lbl, m.xrefs().get(0).lbl());
+        assertFalse(m.isDeprecated());
     }
 
     public static Meta build() {
@@ -39,14 +38,14 @@ public class MetaTest {
         DefinitionPropertyValue def = new DefinitionPropertyValue.
                 Builder().
                 val(defval).
-                xrefs(Arrays.asList(defXrefs)).
+                xrefs(List.of(defXrefs)).
                 build();
 
         return new Meta.Builder().
                 definition(def).
-                synonyms(Collections.singletonList(s)).
-                xrefs(Collections.singletonList(xref)).
-                subsets(Arrays.asList(subsets))
+                synonyms(List.of(s)).
+                xrefs(List.of(xref)).
+                subsets(List.of(subsets))
                 .deprecated(false)
                 .build();
     }

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/model/NodeTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/model/NodeTest.java
@@ -19,14 +19,14 @@ public class NodeTest {
 	public void test() {
         Node n = build();
         Node p = buildParent();
-        assertEquals(id, n.getId());
-        assertEquals(lbl, n.getLabel());
-        assertEquals(parent_id, p.getId());
-        assertEquals(parent_lbl, p.getLabel());
+        assertEquals(id, n.id());
+        assertEquals(lbl, n.label());
+        assertEquals(parent_id, p.id());
+        assertEquals(parent_lbl, p.label());
 		
 		Meta m = MetaTest.build();
 		MetaTest.testMeta(m);
-		assertNull(p.getMeta());
+		assertNull(p.meta());
 	}
 	
     public static Node build() {

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/model/axiom/AdvancedAxiomsTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/model/axiom/AdvancedAxiomsTest.java
@@ -7,7 +7,6 @@ import org.geneontology.obographs.core.model.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -16,41 +15,35 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class AdvancedAxiomsTest {
 
     @Test
-    public void test() throws JsonProcessingException {
+    void test() throws JsonProcessingException {
         GraphDocument d = buildGD();
-        
-        Graph g = d.getGraphs().get(0);
-        assertEquals(1,g.getLogicalDefinitionAxioms().size());
- 
+
+        Graph g = d.graphs().get(0);
+        assertEquals(1, g.logicalDefinitionAxioms().size());
+
         System.out.println(OgJsonGenerator.render(d));
         System.out.println(OgYamlGenerator.render(d));
     }
-    
+
     public static GraphDocument buildGD() {
         Graph g = buildGraph();
-        List<Graph> graphs =  (List<Graph>) Collections.singletonList(g);
+        List<Graph> graphs = List.of(g);
 
-        Map<Object,Object> context = new HashMap<>();
-        context.put("GO", "http://purl.obolibrary.org/obo/GO_");
+        Map<Object, Object> context = Map.of("GO", "http://purl.obolibrary.org/obo/GO_");
 
-        GraphDocument d = new GraphDocument.Builder().
-                context(context).
-                graphs(graphs).build();
-        return d;
+        return new GraphDocument.Builder().context(context).graphs(graphs).build();
     }
-
 
 
     public static Graph buildGraph() {
         Node n = NodeTest.build();
         Edge e = EdgeTest.build();
-        
+
         List<Node> nodes = Collections.singletonList(n);
         List<Edge> edges = Collections.singletonList(e);
         List<EquivalentNodesSet> enss = Collections.singletonList(EquivalentNodesSetTest.build());
         List<LogicalDefinitionAxiom> ldas = Collections.singletonList(LogicalDefinitionAxiomTest.build());
-        Graph g = new Graph.Builder().nodes(nodes ).edges(edges).equivalentNodesSets(enss).logicalDefinitionAxioms(ldas).build();
-        return g;
+        return new Graph.Builder().nodes(nodes).edges(edges).equivalentNodesSets(enss).logicalDefinitionAxioms(ldas).build();
     }
 
 }

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/model/axiom/DomainRangeAxiomTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/model/axiom/DomainRangeAxiomTest.java
@@ -11,9 +11,9 @@ public class DomainRangeAxiomTest {
     static String range = "X:1";
     
     @Test
-    public void test() {
+    void test() {
         DomainRangeAxiom a = build();
-        assertEquals(pred, a.getPredicateId());
+        assertEquals(pred, a.predicateId());
     }
 
     public static DomainRangeAxiom build() {

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/model/axiom/EquivalentNodesSetTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/model/axiom/EquivalentNodesSetTest.java
@@ -1,10 +1,7 @@
 package org.geneontology.obographs.core.model.axiom;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -12,16 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class EquivalentNodesSetTest {
 
     @Test
-    public void test() throws JsonProcessingException {
+    void test() {
         EquivalentNodesSet ens = build();
-        assertEquals(2, ens.getNodeIds().size());
+        assertEquals(2, ens.nodeIds().size());
     }
-
-
 
     public static EquivalentNodesSet build() {
         String[] ids = {"X:1", "X:2"};
-        Set<String> nodeIds = new HashSet<>(Arrays.asList(ids));
+        Set<String> nodeIds = Set.of(ids);
         return new EquivalentNodesSet.Builder().nodeIds(nodeIds).representativeNodeId(ids[0]).build();
     }
 

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/model/axiom/ExistentialRestrictionAxiomTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/model/axiom/ExistentialRestrictionAxiomTest.java
@@ -1,6 +1,5 @@
 package org.geneontology.obographs.core.model.axiom;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -10,20 +9,15 @@ public class ExistentialRestrictionAxiomTest {
     private static final String REL = "part_of";
     private static final String FILLER = "Z:1";
 
-
     @Test
-    public void test() throws JsonProcessingException {
+    void test() {
         ExistentialRestrictionExpression r = build();
-        assertEquals(REL, r.getPropertyId());
-        assertEquals(FILLER, r.getFillerId());
+        assertEquals(REL, r.propertyId());
+        assertEquals(FILLER, r.fillerId());
     }
 
-
-
     public static ExistentialRestrictionExpression build() {
-
         return new ExistentialRestrictionExpression.Builder().propertyId(REL).fillerId(FILLER).build();
-
     }
 
 

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/model/axiom/LogicalDefinitionAxiomTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/model/axiom/LogicalDefinitionAxiomTest.java
@@ -1,11 +1,7 @@
 package org.geneontology.obographs.core.model.axiom;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -15,19 +11,15 @@ public class LogicalDefinitionAxiomTest {
     private static final String DC = "A:1";
     
     @Test
-    public void test() throws JsonProcessingException {
+    void test() {
         LogicalDefinitionAxiom lda = build();
-        assertEquals(DC, lda.getDefinedClassId());
+        assertEquals(DC, lda.definedClassId());
     }
     
     public static LogicalDefinitionAxiom build() {
-        String[] ids = {"X:1", "X:2"};
-        List<String> nodeIds = new ArrayList<>(
-                Arrays.asList(ids));
-        List<ExistentialRestrictionExpression> rs = 
-                Collections.singletonList(ExistentialRestrictionAxiomTest.build());
+        List<String> nodeIds = List.of("X:1", "X:2");
+        List<ExistentialRestrictionExpression> rs = List.of(ExistentialRestrictionAxiomTest.build());
         return new LogicalDefinitionAxiom.Builder().definedClassId(DC).genusIds(nodeIds).restrictions(rs).build();
-        
     }
 
 

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/model/axiom/PropertyChainAxiomTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/model/axiom/PropertyChainAxiomTest.java
@@ -2,7 +2,6 @@ package org.geneontology.obographs.core.model.axiom;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -14,18 +13,16 @@ public class PropertyChainAxiomTest {
     static String pc2 = "part_of";
     
     @Test
-    public void test() {
+    void test() {
         PropertyChainAxiom a = build();
-        assertEquals(pred, a.getPredicateId());
-        assertEquals(pc1, a.getChainPredicateIds().get(0));
-        assertEquals(pc2, a.getChainPredicateIds().get(1));
+        assertEquals(pred, a.predicateId());
+        assertEquals(pc1, a.chainPredicateIds().get(0));
+        assertEquals(pc2, a.chainPredicateIds().get(1));
     }
 
     
     public static PropertyChainAxiom build() {
-        List<String> pc  = new ArrayList<>();
-        pc.add(pc1);
-        pc.add(pc2);
+        List<String> pc = List.of(pc1, pc2);
         return new PropertyChainAxiom.Builder().predicateId(pred).chainPredicateIds(pc).build();
         
     }

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/model/meta/SynonymPropertyValueTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/model/meta/SynonymPropertyValueTest.java
@@ -1,6 +1,6 @@
 package org.geneontology.obographs.core.model.meta;
 
-import org.geneontology.obographs.core.model.meta.AbstractSynonymPropertyValue.SCOPES;
+import org.geneontology.obographs.core.model.meta.AbstractSynonymPropertyValue.Scope;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -12,21 +12,17 @@ public class SynonymPropertyValueTest {
 
     static String[] synXrefs = {"GOC:go_curators"};
     static String val = "cell nucleus";
-    static SCOPES scope = SynonymPropertyValue.SCOPES.EXACT;
+    static Scope scope = Scope.EXACT;
     static String synonymType = "special_synonym";
 
     @Test
-    public void test() {
+    void test() {
         SynonymPropertyValue spv = build();
-        testSyn(spv);
-    }
-
-    public void testSyn(SynonymPropertyValue spv) {
-        assertEquals(synonymType, spv.getSynonymType());
-        assertEquals(val, spv.getVal());
+        assertEquals(synonymType, spv.synonymType());
+        assertEquals(val, spv.val());
         assertTrue(spv.isExact());
-        assertEquals(1, spv.getXrefs().size());
-        assertEquals(synXrefs[0], spv.getXrefs().get(0));
+        assertEquals(1, spv.xrefs().size());
+        assertEquals(synXrefs[0], spv.xrefs().get(0));
     }
 
     public static SynonymPropertyValue build() {

--- a/obographs-core/src/test/java/org/geneontology/obographs/core/model/meta/XrefPropertyValueTest.java
+++ b/obographs-core/src/test/java/org/geneontology/obographs/core/model/meta/XrefPropertyValueTest.java
@@ -10,13 +10,10 @@ public class XrefPropertyValueTest {
     public static String lbl = "foo disease";
     
     @Test
-    public void test() {
+    void test() {
         XrefPropertyValue spv = build();
-        testSyn(spv);
-    }
-
-    public void testSyn(XrefPropertyValue spv) {
-        assertEquals(val, spv.getVal());
+        assertEquals(val, spv.val());
+        assertEquals(lbl, spv.lbl());
     }
 
     public static XrefPropertyValue build() {

--- a/obographs-owlapi/pom.xml
+++ b/obographs-owlapi/pom.xml
@@ -5,16 +5,11 @@
     <parent>
         <groupId>org.geneontology.obographs</groupId>
         <artifactId>obographs</artifactId>
-        <version>0.3.1</version>
+        <version>0.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>obographs-owlapi</artifactId>
-
-    <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-    </properties>
 
     <dependencies>
         <dependency>
@@ -25,12 +20,12 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.48</version>
+            <version>1.75</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.owlapi</groupId>
             <artifactId>owlapi-distribution</artifactId>
-            <version>4.5.16</version>
+            <version>4.5.23</version>
         </dependency>
         <dependency>
             <groupId>com.io-informatics.oss</groupId>
@@ -54,12 +49,10 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.3</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/obographs-owlapi/src/main/java/org/geneontology/obographs/owlapi/FromOwl.java
+++ b/obographs-owlapi/src/main/java/org/geneontology/obographs/owlapi/FromOwl.java
@@ -1,11 +1,9 @@
 package org.geneontology.obographs.owlapi;
 
 import com.github.jsonldjava.core.Context;
-import org.geneontology.obographs.core.model.AbstractNode.RDFTYPES;
 import org.geneontology.obographs.core.model.*;
-import org.geneontology.obographs.core.model.Node.Builder;
 import org.geneontology.obographs.core.model.axiom.*;
-import org.geneontology.obographs.core.model.meta.AbstractSynonymPropertyValue.SCOPES;
+import org.geneontology.obographs.core.model.meta.AbstractSynonymPropertyValue.Scope;
 import org.geneontology.obographs.core.model.meta.BasicPropertyValue;
 import org.geneontology.obographs.core.model.meta.DefinitionPropertyValue;
 import org.geneontology.obographs.core.model.meta.SynonymPropertyValue;
@@ -17,8 +15,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import org.geneontology.obographs.core.model.AbstractNode.PropertyType;
 
 /**
  * Implements OWL to OG translation
@@ -73,9 +69,6 @@ public class FromOwl {
      */
     public Graph generateGraph(OWLOntology ontology) {
 
-        SynonymVocabulary synonymVocabulary = new SynonymVocabulary();
-
-
         OWLOntologyID ontId = ontology.getOntologyID();
         String graphId = ontId.getOntologyIRI().isPresent() ? getNodeId(ontId.getOntologyIRI().get()) : "";
         String version = ontId.getVersionIRI().isPresent() ? getNodeId(ontId.getVersionIRI().get()) : "";
@@ -89,302 +82,12 @@ public class FromOwl {
 
         // iterate over all axioms and push to relevant builders
         for (OWLAxiom ax : sortedAxioms) {
-
             Meta meta = buildMeta(ax);
-
-            if (ax instanceof OWLDeclarationAxiom) {
-                OWLDeclarationAxiom dax = ((OWLDeclarationAxiom) ax);
-                OWLEntity e = dax.getEntity();
-                String id = e.getIRI().toString();
-                if (e instanceof OWLClass) {
-                    oboGraphBuilder.addNodeType(id, RDFTYPES.CLASS);
-                } else if (e instanceof OWLDataProperty) {
-                    oboGraphBuilder.addNodeType(id, PropertyType.DATA);
-                } else if (e instanceof OWLObjectProperty) {
-                    oboGraphBuilder.addNodeType(id, PropertyType.OBJECT);
-                } else if (e instanceof OWLAnnotationProperty) {
-                    oboGraphBuilder.addNodeType(id, PropertyType.ANNOTATION);
-                } else if (e instanceof OWLNamedIndividual) {
-                    oboGraphBuilder.addNodeType(id, RDFTYPES.INDIVIDUAL);
-                }
-            } else if (ax instanceof OWLLogicalAxiom) {
-                // LOGICAL AXIOMS
-
-                if (ax instanceof OWLSubClassOfAxiom) {
-                    // SUBCLASS
-
-                    OWLSubClassOfAxiom sca = (OWLSubClassOfAxiom) ax;
-                    OWLClassExpression subc = sca.getSubClass();
-                    OWLClassExpression supc = sca.getSuperClass();
-
-                    if (subc.isAnonymous()) {
-                        // GCI
-
-                        /*
-                         * TBD: Model for GCIs. See https://github.com/obophenotype/uberon/wiki/Evolutionary-variability-GCIs
-                        if (subc instanceof OWLObjectIntersectionOf) {
-                            OBOClassDef cdef = getClassDef(((OWLObjectIntersectionOf)subc).getOperands());
-                            if (cdef.genusClassIds.size() == 1) {
-                                subj = cdef.genusClassIds.get(0);
-                            }
-
-                            if (subc instanceof OWLObjectSomeValuesFrom) {
-                                // Some axioms such as phylogenetic GCIs are encoded this way
-                                ExistentialRestrictionExpression r = getRestriction(subc);
-                                subj = r.getFillerId();
-                            }
-                        }
-                         */
-
-                    } else if (subc.isNamed()) {
-                        // SUBJECT IS NAMED CLASS (non-GCI)
-                        String subj = getClassId((OWLClass) subc);
-
-                        oboGraphBuilder.addNodeType(subj, RDFTYPES.CLASS);
-
-                        if (supc.isAnonymous()) {
-                            if (supc instanceof OWLObjectSomeValuesFrom) {
-                                ExistentialRestrictionExpression r = getRestriction(supc);
-                                if (r == null) {
-                                    oboGraphBuilder.addUntranslatedAxiom(sca);
-                                } else {
-                                    oboGraphBuilder.addEdge(subj, r.getPropertyId(), r.getFillerId(), meta);
-                                }
-                            } else if (supc instanceof OWLObjectAllValuesFrom) {
-                                OWLObjectAllValuesFrom avf = (OWLObjectAllValuesFrom) supc;
-                                OWLObjectPropertyExpression property = avf.getProperty();
-                                if (property instanceof OWLObjectProperty) {
-                                    if (avf.getFiller().isNamed()) {
-                                        String propertyId = getPropertyId(property);
-                                        DomainRangeAxiom domainRangeAxiom = oboGraphBuilder.getDomainRangeAxiomBuilder(propertyId).build();
-                                        Edge edge = buildEdge(subj,
-                                                //TODO CHECK!!!
-                                                domainRangeAxiom.getPredicateId(),
-                                                getClassId(avf.getFiller().asOWLClass()),
-                                                meta);
-                                        oboGraphBuilder.addPropertyEdgeDefinitions(propertyId, edge);
-                                    } else {
-                                        oboGraphBuilder.addUntranslatedAxiom(sca);
-                                    }
-                                } else if (property instanceof OWLObjectInverseOf) {
-                                    OWLObjectInverseOf iop = (OWLObjectInverseOf) property;
-                                    if (avf.getFiller().isNamed() && iop.isNamed()) {
-                                        String pid = getPropertyId(iop.getInverse());
-                                        Edge edge = buildEdge(subj, INVERSE_OF, pid, meta);
-                                        oboGraphBuilder.addPropertyEdgeDefinitions(pid, edge);
-                                    } else {
-                                        oboGraphBuilder.addUntranslatedAxiom(sca);
-                                    }
-                                }
-                            }
-                        } else {
-                            oboGraphBuilder.addEdge(subj, SUBCLASS_OF, getClassId((OWLClass) supc), meta);
-                        }
-                    } else {
-                        // Logically impossible to reach this? subj is either named or anonymous
-                        oboGraphBuilder.addUntranslatedAxiom(sca);
-                    }
-                } else if (ax instanceof OWLClassAssertionAxiom) {
-                    OWLClassAssertionAxiom ca = (OWLClassAssertionAxiom) ax;
-
-                    String subj = getIndividualId(ca.getIndividual());
-                    String obj;
-                    OWLClassExpression cx = ca.getClassExpression();
-                    if (cx.isAnonymous()) {
-                        oboGraphBuilder.addUntranslatedAxiom(ca);
-                        continue;
-                    } else {
-                        obj = getClassId(cx.asOWLClass());
-                    }
-                    oboGraphBuilder.addEdge(subj, TYPE, obj, meta);
-                    oboGraphBuilder.addNodeId(subj); // always include
-                    oboGraphBuilder.addNodeId(obj); // always include
-
-                } else if (ax instanceof OWLObjectPropertyAssertionAxiom) {
-                    OWLObjectPropertyAssertionAxiom opa = (OWLObjectPropertyAssertionAxiom) ax;
-
-                    String subj = getIndividualId(opa.getSubject());
-                    String obj = getIndividualId(opa.getObject());
-                    if (opa.getProperty().isAnonymous()) {
-                        oboGraphBuilder.addUntranslatedAxiom(opa);
-                    } else {
-                        String pred = getPropertyId(opa.getProperty());
-                        oboGraphBuilder.addEdge(subj, pred, obj, meta);
-                    }
-                    // always include subject node of an OPA
-                    oboGraphBuilder.addNodeId(subj);
-                } else if (ax instanceof OWLEquivalentClassesAxiom) {
-                    // EQUIVALENT
-                    OWLEquivalentClassesAxiom eca = (OWLEquivalentClassesAxiom) ax;
-                    List<OWLClassExpression> xs = eca.getClassExpressionsAsList();
-                    List<OWLClassExpression> anonXs = xs.stream()
-                            .filter(IsAnonymous::isAnonymous)
-                            .collect(Collectors.toUnmodifiableList());
-                    List<OWLClassExpression> namedXs = xs.stream()
-                            .filter(IsAnonymous::isNamed)
-                            .collect(Collectors.toUnmodifiableList());
-                    if (anonXs.isEmpty()) {
-                        Set<String> xClassIds = namedXs.stream()
-                                .map(x -> getClassId((OWLClass) x))
-                                .collect(Collectors.toCollection(LinkedHashSet::new));
-                        // EquivalentNodesSet
-                        // all classes in equivalence axiom are named
-                        // TODO: merge pairwise assertions into a clique
-                        //TODO: EquivalentNodesSet.representativeNodeId() is not set in the production code!!
-                        EquivalentNodesSet enset = new EquivalentNodesSet.Builder().nodeIds(xClassIds).meta(nullIfEmpty(meta)).build();
-                        oboGraphBuilder.addEquivalentNodesSet(enset);
-                    } else {
-                        // possibilities are:
-                        //  - LogicalDefinitionAxiom
-                        //  - TBD
-
-                        if (anonXs.size() == 1 && namedXs.size() == 1) {
-
-                            OWLClassExpression anonX = anonXs.get(0);
-                            if (anonX instanceof OWLObjectIntersectionOf) {
-
-                                Set<OWLClassExpression> ixs = ((OWLObjectIntersectionOf) anonX).getOperands();
-
-                                OBOClassDef classDef = getClassDef(ixs);
-                                if (classDef != null && !classDef.restrs.contains(null)) {
-                                    LogicalDefinitionAxiom lda = new LogicalDefinitionAxiom.Builder()
-                                            .definedClassId(getClassId((OWLClass) namedXs.get(0)))
-                                            .genusIds(classDef.genusClassIds)
-                                            .restrictions(classDef.restrs)
-                                            .build();
-                                    oboGraphBuilder.addLogicalDefinitionAxiom(lda);
-                                } else {
-                                    oboGraphBuilder.addUntranslatedAxiom(eca);
-                                }
-                            }
-                        }
-                    }
-                } else if (ax instanceof OWLObjectPropertyAxiom) {
-                    if (ax instanceof OWLSubObjectPropertyOfAxiom) {
-                        OWLSubObjectPropertyOfAxiom spa = (OWLSubObjectPropertyOfAxiom) ax;
-                        if (spa.getSubProperty().isNamed() && spa.getSuperProperty().isNamed()) {
-                            String subj = getPropertyId(spa.getSubProperty());
-                            String obj = getPropertyId(spa.getSuperProperty());
-                            oboGraphBuilder.addEdge(subj, SUBPROPERTY_OF, obj, meta);
-                        }
-
-                    } else if (ax instanceof OWLInverseObjectPropertiesAxiom) {
-                        OWLInverseObjectPropertiesAxiom ipa = (OWLInverseObjectPropertiesAxiom) ax;
-                        if (ipa.getFirstProperty().isNamed() && ipa.getSecondProperty().isNamed()) {
-                            String p1 = getPropertyId(ipa.getFirstProperty());
-                            String p2 = getPropertyId(ipa.getSecondProperty());
-                            oboGraphBuilder.addEdge(p1, INVERSE_OF, p2, meta);
-                        }
-                    } else if (ax instanceof OWLSubPropertyChainOfAxiom) {
-                        OWLSubPropertyChainOfAxiom spc = (OWLSubPropertyChainOfAxiom) ax;
-                        if (spc.getSuperProperty().isNamed()) {
-                            String p = getPropertyId(spc.getSuperProperty());
-                            List<String> cpids = spc.getPropertyChain().stream()
-                                    .map(cp -> cp.isAnonymous() ? null : getPropertyId(cp))
-                                    .collect(Collectors.toList());
-                            if (cpids.stream().noneMatch(Objects::isNull)) {
-                                oboGraphBuilder.addPropertyChainAxiom(new PropertyChainAxiom.Builder().predicateId(p).chainPredicateIds(cpids).build());
-                            }
-                        }
-                    } else if (ax instanceof OWLObjectPropertyRangeAxiom) {
-                        OWLObjectPropertyRangeAxiom rax = (OWLObjectPropertyRangeAxiom) ax;
-                        OWLClassExpression rc = rax.getRange();
-                        if (rc.isNamed()) {
-                            String propertyId = getPropertyId(rax.getProperty());
-                            oboGraphBuilder.addPropertyRangeClassId(propertyId, getClassId(rc.asOWLClass()));
-                        }
-                    } else if (ax instanceof OWLObjectPropertyDomainAxiom) {
-                        OWLObjectPropertyDomainAxiom rax = (OWLObjectPropertyDomainAxiom) ax;
-                        OWLClassExpression rc = rax.getDomain();
-                        if (rc.isNamed()) {
-                            String propertyId = getPropertyId(rax.getProperty());
-                            oboGraphBuilder.addPropertyDomainClassId(propertyId, getClassId(rc.asOWLClass()));
-                        }
-                    }
-                } else {
-                    oboGraphBuilder.addUntranslatedAxiom(ax);
-                }
-            } else {
-                // NON-LOGICAL AXIOMS
-                if (ax instanceof OWLAnnotationAssertionAxiom) {
-                    OWLAnnotationAssertionAxiom aaa = (OWLAnnotationAssertionAxiom) ax;
-                    OWLAnnotationProperty p = aaa.getProperty();
-                    OWLAnnotationSubject s = aaa.getSubject();
-
-                    // non-blank nodes
-                    if (s instanceof IRI) {
-                        IRI pIRI = p.getIRI();
-                        String subj = getNodeId((IRI) s);
-
-                        OWLAnnotationValue v = aaa.getValue();
-                        String lv = null;
-                        if (v instanceof OWLLiteral) {
-                            lv = ((OWLLiteral) v).getLiteral();
-                        }
-                        if (p.isLabel() && lv != null) {
-                            oboGraphBuilder.addNodeLabel(subj, lv);
-                        } else if (isDefinitionProperty(pIRI) && lv != null) {
-                            DefinitionPropertyValue def = new DefinitionPropertyValue.Builder()
-                                    .val(lv)
-                                    .xrefs(meta.getXrefsValues())
-                                    .build();
-                            oboGraphBuilder.addNodeDefinitionPropertyValue(subj, def);
-                        } else if (isHasXrefProperty(pIRI) && lv != null) {
-                            XrefPropertyValue xref = new XrefPropertyValue.Builder()
-                                    .val(lv)
-                                    .build();
-                            oboGraphBuilder.addNodeXrefPropertyValue(subj, xref);
-                        } else if (p.isDeprecated() && aaa.isDeprecatedIRIAssertion()) {
-                            oboGraphBuilder.setNodeDeprecated(subj, true);
-                        } else if (p.isComment() && lv != null) {
-                            oboGraphBuilder.addNodeComment(subj, lv);
-                        } else if (isOboInOwlIdProperty(pIRI)) {
-                            // skip
-                        } else if (isInSubsetProperty(pIRI)) {
-                            oboGraphBuilder.addNodeSubset(subj, v.toString());
-                        } else if (synonymVocabulary.contains(pIRI.toString()) && lv != null) {
-                            SCOPES scope = synonymVocabulary.get(pIRI.toString());
-                            String synonymType = "";
-                            for (OWLAnnotation a : aaa.getAnnotations()) {
-                                if (a.getProperty().getIRI().toString().equals(SynonymVocabulary.SYNONYM_TYPE)) {
-                                    synonymType = a.getValue().toString();
-                                } else {
-                                    // TODO: capture these in meta
-                                }
-                            }
-
-                            SynonymPropertyValue syn = new SynonymPropertyValue.Builder()
-                                    .pred(scope.pred())
-                                    .synonymType(synonymType)
-                                    .val(lv)
-                                    .xrefs(meta.getXrefsValues())
-                                    .build();
-                            oboGraphBuilder.addNodeSynonymPropertyValue(subj, syn);
-                        } else {
-                            String val;
-                            if (v instanceof IRI) {
-                                val = ((IRI) v).toString();
-                            } else if (v instanceof OWLLiteral) {
-                                val = ((OWLLiteral) v).getLiteral();
-                            } else if (v instanceof OWLAnonymousIndividual) {
-                                val = ((OWLAnonymousIndividual) v).getID().toString();
-                            } else {
-                                val = "";
-                            }
-
-                            BasicPropertyValue basicPropertyValue = new BasicPropertyValue.Builder()
-                                    .pred(getPropertyId(p))
-                                    .val(val)
-                                    .build();
-
-                            oboGraphBuilder.addNodeBasicPropertyValue(subj, basicPropertyValue);
-                        }
-
-                    } else {
-                        // subject is anonymous
-                        oboGraphBuilder.addUntranslatedAxiom(aaa);
-                    }
-                }
+            switch (ax) {
+                case OWLDeclarationAxiom dax -> convertOWLDeclarationAxiom(dax, oboGraphBuilder);
+                case OWLLogicalAxiom owlLogicalAxiom -> convertOWLLogicalAxiom(owlLogicalAxiom, oboGraphBuilder, meta);
+                case OWLAnnotationAssertionAxiom aaa -> convertOWLAnnotationAssertionAxiom(aaa, oboGraphBuilder, meta);
+                default -> oboGraphBuilder.addUntranslatedAxiom(ax);
             }
         }
 
@@ -398,6 +101,283 @@ public class FromOwl {
         return oboGraphBuilder.buildGraph();
     }
 
+    private void convertOWLDeclarationAxiom(OWLDeclarationAxiom dax, OboGraphBuilder oboGraphBuilder) {
+        OWLEntity e = dax.getEntity();
+        String id = e.getIRI().toString();
+        switch (e) {
+            case OWLClass ignored -> oboGraphBuilder.addNodeType(id, RdfType.CLASS);
+            case OWLNamedIndividual ignored -> oboGraphBuilder.addNodeType(id, RdfType.INDIVIDUAL);
+            case OWLDataProperty ignored -> oboGraphBuilder.addNodeType(id, PropertyType.DATA);
+            case OWLObjectProperty ignored -> oboGraphBuilder.addNodeType(id, PropertyType.OBJECT);
+            case OWLAnnotationProperty ignored -> oboGraphBuilder.addNodeType(id, PropertyType.ANNOTATION);
+            default -> {
+                // ignore
+            }
+        }
+    }
+
+    // LOGICAL AXIOMS
+    private void convertOWLLogicalAxiom(OWLLogicalAxiom owlLogicalAxiom, OboGraphBuilder oboGraphBuilder, Meta meta) {
+        switch (owlLogicalAxiom) {
+            case OWLSubClassOfAxiom sca -> convertOWLSubClassOfAxiom(sca, oboGraphBuilder, meta);
+            case OWLClassAssertionAxiom ca -> convertOWLClassAssertionAxiom(ca, oboGraphBuilder, meta);
+            case OWLObjectPropertyAssertionAxiom opa -> convertOWLObjectPropertyAssertionAxiom(opa, oboGraphBuilder, meta);
+            case OWLEquivalentClassesAxiom eca -> convertOWLEquivalentClassesAxiom(eca, meta, oboGraphBuilder);
+            case OWLObjectPropertyAxiom objectPropertyAxiom -> convertOWLObjectPropertyAxiom(objectPropertyAxiom, oboGraphBuilder, meta);
+            default -> oboGraphBuilder.addUntranslatedAxiom(owlLogicalAxiom);
+        }
+    }
+
+    private void convertOWLSubClassOfAxiom(OWLSubClassOfAxiom sca, OboGraphBuilder oboGraphBuilder, Meta meta) {
+        OWLClassExpression subc = sca.getSubClass();
+
+        if (subc.isAnonymous()) {
+            // GCI
+            /*
+             * TBD: Model for GCIs. See https://github.com/obophenotype/uberon/wiki/Evolutionary-variability-GCIs
+            if (subc instanceof OWLObjectIntersectionOf) {
+                OBOClassDef cdef = getClassDef(((OWLObjectIntersectionOf)subc).getOperands());
+                if (cdef.genusClassIds.size() == 1) {
+                    subj = cdef.genusClassIds.get(0);
+                }
+
+                if (subc instanceof OWLObjectSomeValuesFrom) {
+                    // Some axioms such as phylogenetic GCIs are encoded this way
+                    ExistentialRestrictionExpression r = getRestriction(subc);
+                    subj = r.getFillerId();
+                }
+            }
+             */
+        } else if (subc.isNamed()) {
+            // SUBJECT IS NAMED CLASS (non-GCI)
+            convertNamedSubClassOfAxiom(sca, oboGraphBuilder, meta);
+        } else {
+            // Logically impossible to reach this? subj is either named or anonymous
+            oboGraphBuilder.addUntranslatedAxiom(sca);
+        }
+    }
+
+    private void convertNamedSubClassOfAxiom(OWLSubClassOfAxiom sca, OboGraphBuilder oboGraphBuilder, Meta meta) {
+        String subj = getClassId((OWLClass) sca.getSubClass());
+        oboGraphBuilder.addNodeType(subj, RdfType.CLASS);
+
+        OWLClassExpression supc = sca.getSuperClass();
+        if (supc.isAnonymous()) {
+            if (supc instanceof OWLObjectSomeValuesFrom) {
+                ExistentialRestrictionExpression r = getRestriction(supc);
+                if (r == null) {
+                    oboGraphBuilder.addUntranslatedAxiom(sca);
+                } else {
+                    oboGraphBuilder.addEdge(subj, r.propertyId(), r.fillerId(), meta);
+                }
+            } else if (supc instanceof OWLObjectAllValuesFrom avf) {
+                convertObjectAllValuesFrom(sca, oboGraphBuilder, meta, avf, subj);
+            }
+        } else {
+            oboGraphBuilder.addEdge(subj, SUBCLASS_OF, getClassId((OWLClass) supc), meta);
+        }
+    }
+
+    private void convertObjectAllValuesFrom(OWLSubClassOfAxiom sca, OboGraphBuilder oboGraphBuilder, Meta meta, OWLObjectAllValuesFrom avf, String subj) {
+        OWLObjectPropertyExpression property = avf.getProperty();
+        switch (property) {
+            case OWLObjectProperty owlObjectProperty when avf.getFiller().isNamed() -> {
+                String propertyId = getPropertyId(property);
+                DomainRangeAxiom domainRangeAxiom = oboGraphBuilder.getDomainRangeAxiomBuilder(propertyId).build();
+                Edge edge = buildEdge(subj,
+                        //TODO CHECK!!!
+                        domainRangeAxiom.predicateId(),
+                        getClassId(avf.getFiller().asOWLClass()),
+                        meta);
+                oboGraphBuilder.addPropertyEdgeDefinitions(propertyId, edge);
+            }
+            case OWLObjectInverseOf iop when avf.getFiller().isNamed() && iop.isNamed() -> {
+                String pid = getPropertyId(iop.getInverse());
+                Edge edge = buildEdge(subj, INVERSE_OF, pid, meta);
+                oboGraphBuilder.addPropertyEdgeDefinitions(pid, edge);
+            }
+            default -> oboGraphBuilder.addUntranslatedAxiom(sca);
+        }
+    }
+
+    private void convertOWLClassAssertionAxiom(OWLClassAssertionAxiom ca, OboGraphBuilder oboGraphBuilder, Meta meta) {
+        OWLClassExpression cx = ca.getClassExpression();
+        if (cx.isAnonymous()) {
+            oboGraphBuilder.addUntranslatedAxiom(ca);
+        } else {
+            String subj = getIndividualId(ca.getIndividual());
+            String obj = getClassId(cx.asOWLClass());
+            oboGraphBuilder.addEdge(subj, TYPE, obj, meta);
+            oboGraphBuilder.addNodeId(subj); // always include
+            oboGraphBuilder.addNodeId(obj); // always include
+        }
+    }
+
+    private void convertOWLObjectPropertyAssertionAxiom(OWLObjectPropertyAssertionAxiom opa, OboGraphBuilder oboGraphBuilder, Meta meta) {
+        String subj = getIndividualId(opa.getSubject());
+        String obj = getIndividualId(opa.getObject());
+        if (opa.getProperty().isAnonymous()) {
+            oboGraphBuilder.addUntranslatedAxiom(opa);
+        } else {
+            String pred = getPropertyId(opa.getProperty());
+            oboGraphBuilder.addEdge(subj, pred, obj, meta);
+        }
+        // always include subject node of an OPA
+        oboGraphBuilder.addNodeId(subj);
+    }
+
+    private void convertOWLEquivalentClassesAxiom(OWLEquivalentClassesAxiom eca, Meta meta, OboGraphBuilder oboGraphBuilder) {
+        List<OWLClassExpression> xs = eca.getClassExpressionsAsList();
+        List<OWLClassExpression> anonXs = xs.stream()
+                .filter(IsAnonymous::isAnonymous)
+                .toList();
+        List<OWLClassExpression> namedXs = xs.stream()
+                .filter(IsAnonymous::isNamed)
+                .toList();
+        if (anonXs.isEmpty()) {
+            Set<String> xClassIds = namedXs.stream()
+                    .map(x -> getClassId((OWLClass) x))
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            // EquivalentNodesSet
+            // all classes in equivalence axiom are named
+            // TODO: merge pairwise assertions into a clique
+            //TODO: EquivalentNodesSet.representativeNodeId() is not set in the production code!!
+            EquivalentNodesSet enset = new EquivalentNodesSet.Builder().nodeIds(xClassIds).meta(nullIfEmpty(meta)).build();
+            oboGraphBuilder.addEquivalentNodesSet(enset);
+        } else {
+            // possibilities are:
+            //  - LogicalDefinitionAxiom
+            //  - TBD
+            if (anonXs.size() == 1 && namedXs.size() == 1) {
+                OWLClassExpression anonX = anonXs.get(0);
+                if (anonX instanceof OWLObjectIntersectionOf owlObjectIntersectionOf) {
+                    Set<OWLClassExpression> ixs = owlObjectIntersectionOf.getOperands();
+                    OBOClassDef classDef = getClassDef(ixs);
+                    if (classDef != null && !classDef.restrs.contains(null)) {
+                        LogicalDefinitionAxiom lda = new LogicalDefinitionAxiom.Builder()
+                                .definedClassId(getClassId((OWLClass) namedXs.get(0)))
+                                .genusIds(classDef.genusClassIds)
+                                .restrictions(classDef.restrs)
+                                .build();
+                        oboGraphBuilder.addLogicalDefinitionAxiom(lda);
+                    } else {
+                        oboGraphBuilder.addUntranslatedAxiom(eca);
+                    }
+                }
+            }
+        }
+    }
+
+    private void convertOWLObjectPropertyAxiom(OWLObjectPropertyAxiom owlObjectPropertyAxiom, OboGraphBuilder oboGraphBuilder, Meta meta) {
+        switch (owlObjectPropertyAxiom) {
+            case OWLSubObjectPropertyOfAxiom spa when spa.getSubProperty().isNamed() && spa.getSuperProperty().isNamed() -> {
+                String subj = getPropertyId(spa.getSubProperty());
+                String obj = getPropertyId(spa.getSuperProperty());
+                oboGraphBuilder.addEdge(subj, SUBPROPERTY_OF, obj, meta);
+            }
+            case OWLInverseObjectPropertiesAxiom ipa when ipa.getFirstProperty().isNamed() && ipa.getSecondProperty().isNamed() -> {
+                String p1 = getPropertyId(ipa.getFirstProperty());
+                String p2 = getPropertyId(ipa.getSecondProperty());
+                oboGraphBuilder.addEdge(p1, INVERSE_OF, p2, meta);
+            }
+            case OWLSubPropertyChainOfAxiom spc when spc.getSuperProperty().isNamed() -> {
+                String p = getPropertyId(spc.getSuperProperty());
+                List<String> cpids = spc.getPropertyChain().stream()
+                        .map(cp -> cp.isAnonymous() ? null : getPropertyId(cp))
+                        .toList();
+                if (cpids.stream().noneMatch(Objects::isNull)) {
+                    oboGraphBuilder.addPropertyChainAxiom(new PropertyChainAxiom.Builder().predicateId(p).chainPredicateIds(cpids).build());
+                }
+            }
+            case OWLObjectPropertyRangeAxiom propertyRangeAxiom when propertyRangeAxiom.getRange().isNamed() -> {
+                OWLClassExpression rc = propertyRangeAxiom.getRange();
+                String propertyId = getPropertyId(propertyRangeAxiom.getProperty());
+                oboGraphBuilder.addPropertyRangeClassId(propertyId, getClassId(rc.asOWLClass()));
+            }
+            case OWLObjectPropertyDomainAxiom propertyDomainAxiom when propertyDomainAxiom.getDomain().isNamed() -> {
+                OWLClassExpression rc = propertyDomainAxiom.getDomain();
+                String propertyId = getPropertyId(propertyDomainAxiom.getProperty());
+                oboGraphBuilder.addPropertyDomainClassId(propertyId, getClassId(rc.asOWLClass()));
+            }
+            case null, default -> {
+                // do nothing
+            }
+        }
+    }
+
+    private void convertOWLAnnotationAssertionAxiom(OWLAnnotationAssertionAxiom aaa, OboGraphBuilder oboGraphBuilder, Meta meta) {
+        // NON-LOGICAL AXIOMS
+        OWLAnnotationProperty p = aaa.getProperty();
+        OWLAnnotationSubject s = aaa.getSubject();
+
+        // non-blank nodes
+        if (s instanceof IRI sIri) {
+            IRI pIRI = p.getIRI();
+            String subj = getNodeId(sIri);
+
+            OWLAnnotationValue v = aaa.getValue();
+            String lv = (v instanceof OWLLiteral literal) ? literal.getLiteral() : null;
+            if (p.isDeprecated() && aaa.isDeprecatedIRIAssertion()) {
+                oboGraphBuilder.setNodeDeprecated(subj, true);
+            } else if (isOboInOwlIdProperty(pIRI)) {
+                // skip
+            } else if (isInSubsetProperty(pIRI)) {
+                oboGraphBuilder.addNodeSubset(subj, v.toString());
+            } else if (p.isLabel() && lv != null) {
+                oboGraphBuilder.addNodeLabel(subj, lv);
+            } else if (isDefinitionProperty(pIRI) && lv != null) {
+                DefinitionPropertyValue def = new DefinitionPropertyValue.Builder()
+                        .val(lv)
+                        .xrefs(meta.xrefsValues())
+                        .meta(buildBasicPropertyValueMeta(meta))
+                        .build();
+                oboGraphBuilder.addNodeDefinitionPropertyValue(subj, def);
+            } else if (isHasXrefProperty(pIRI) && lv != null) {
+                XrefPropertyValue xref = new XrefPropertyValue.Builder()
+                        .val(lv)
+                        .meta(buildBasicPropertyValueMeta(meta))
+                        .build();
+                oboGraphBuilder.addNodeXrefPropertyValue(subj, xref);
+            } else if (p.isComment() && lv != null) {
+                oboGraphBuilder.addNodeComment(subj, lv);
+            } else if (SynonymVocabulary.containsIri(pIRI.toString()) && lv != null) {
+                Scope scope = SynonymVocabulary.getScope(pIRI.toString());
+                String synonymType = "";
+                for (OWLAnnotation a : aaa.getAnnotations()) {
+                    if (a.getProperty().getIRI().toString().equals(SynonymVocabulary.SYNONYM_TYPE)) {
+                        synonymType = a.getValue().toString();
+                    } else {
+                        // TODO: capture these in meta
+                    }
+                }
+                SynonymPropertyValue syn = new SynonymPropertyValue.Builder()
+                        .pred(scope.pred())
+                        .synonymType(synonymType)
+                        .val(lv)
+                        .xrefs(meta.xrefsValues())
+                        .meta(buildBasicPropertyValueMeta(meta))
+                        .build();
+                oboGraphBuilder.addNodeSynonymPropertyValue(subj, syn);
+            } else {
+                String val = switch (v) {
+                    case IRI iri -> iri.toString();
+                    case OWLLiteral owlLiteral -> owlLiteral.getLiteral();
+                    case OWLAnonymousIndividual owlAnonymousIndividual -> owlAnonymousIndividual.getID().toString();
+                    default -> "";
+                };
+                BasicPropertyValue basicPropertyValue = new BasicPropertyValue.Builder()
+                        .pred(getPropertyId(p))
+                        .val(val)
+                        .meta(buildBasicPropertyValueMeta(meta))
+                        .build();
+                oboGraphBuilder.addNodeBasicPropertyValue(subj, basicPropertyValue);
+            }
+        } else {
+            // subject is anonymous
+            oboGraphBuilder.addUntranslatedAxiom(aaa);
+        }
+    }
+
     static class OboGraphBuilder {
 
         private final String graphId;
@@ -407,7 +387,7 @@ public class FromOwl {
         private final List<EquivalentNodesSet> ensets = new ArrayList<>();
         private final List<LogicalDefinitionAxiom> ldas = new ArrayList<>();
         private final Set<String> nodeIds = new LinkedHashSet<>();
-        private final Map<String, RDFTYPES> nodeTypeMap = new LinkedHashMap<>();
+        private final Map<String, RdfType> nodeTypeMap = new LinkedHashMap<>();
         private final Map<String, String> nodeLabelMap = new LinkedHashMap<>();
         private final Map<String, DomainRangeAxiom.Builder> domainRangeBuilderMap = new LinkedHashMap<>();
         private final List<PropertyChainAxiom> pcas = new ArrayList<>();
@@ -432,15 +412,15 @@ public class FromOwl {
             nodeIds.add(nodeId);
         }
 
-        public void addNodeType(String nodeId, RDFTYPES rdftypes) {
+        public void addNodeType(String nodeId, RdfType rdfType) {
             // ensure all nodes are added, even if they lack a label
             nodeIds.add(nodeId);
-            nodeTypeMap.put(nodeId, rdftypes);
+            nodeTypeMap.put(nodeId, rdfType);
         }
 
         public void addNodeType(String nodeId, PropertyType propertyType) {
             nodeIds.add(nodeId);
-            nodeTypeMap.put(nodeId, RDFTYPES.PROPERTY);
+            nodeTypeMap.put(nodeId, RdfType.PROPERTY);
             nodePropertyTypeMap.put(nodeId, propertyType);
         }
 
@@ -481,13 +461,13 @@ public class FromOwl {
         public void setNodeDeprecated(String nodeId, boolean isDeprecated) {
             Meta.Builder nb = getMetaBuilderForId(nodeId);
             nb.deprecated(isDeprecated);
-            nodeIds.add(nodeId); // TODO: CHECK!! NEW ADDITION in 0.3.1
+            nodeIds.add(nodeId);
         }
 
         public void addNodeComment(String nodeId, String comment) {
             Meta.Builder nb = getMetaBuilderForId(nodeId);
             nb.addComment(comment);
-            nodeIds.add(nodeId); // TODO: CHECK!! NEW ADDITION in 0.3.1
+            nodeIds.add(nodeId);
         }
 
         public void addNodeSubset(String nodeId, String subset) {
@@ -555,7 +535,7 @@ public class FromOwl {
         public Graph buildGraph() {
             List<Node> nodes = new ArrayList<>();
             for (String n : nodeIds) {
-                Builder nb = new Node.Builder()
+                var nb = new Node.Builder()
                         .id(n)
                         .label(nodeLabelMap.getOrDefault(n, ""));
                 if (nodeMetaBuilderMap.containsKey(n)) {
@@ -563,9 +543,9 @@ public class FromOwl {
                     nb.meta(nullIfEmpty(nodeMeta));
                 }
                 if (nodeTypeMap.containsKey(n)) {
-                    RDFTYPES type = nodeTypeMap.get(n);
-                    nb.type(type);
-                    if (type == RDFTYPES.PROPERTY) {
+                    RdfType type = nodeTypeMap.get(n);
+                    nb.rdfType(type);
+                    if (type == RdfType.PROPERTY) {
                         // Change for https://github.com/geneontology/obographs/issues/65
                         PropertyType propertyType = nodePropertyTypeMap.get(n);
                         nb.propertyType(propertyType);
@@ -577,7 +557,7 @@ public class FromOwl {
             List<DomainRangeAxiom> domainRangeAxioms = domainRangeBuilderMap.values()
                     .stream()
                     .map(DomainRangeAxiom.Builder::build)
-                    .collect(Collectors.toList());
+                    .toList();
 
             return new Graph.Builder()
                     .id(graphId)
@@ -590,7 +570,6 @@ public class FromOwl {
                     .propertyChainAxioms(pcas)
                     .build();
         }
-
     }
 
 
@@ -613,11 +592,13 @@ public class FromOwl {
         for (OWLAnnotation ann : anns) {
             OWLAnnotationProperty p = ann.getProperty();
             OWLAnnotationValue v = ann.getValue();
-            String val = v instanceof IRI ? ((IRI) v).toString() : ((OWLLiteral) v).getLiteral();
+            String val = v instanceof IRI iri ? iri.toString() : ((OWLLiteral) v).getLiteral();
             if (ann.isDeprecatedIRIAnnotation()) {
                 builder.deprecated(true);
             } else if (isHasXrefProperty(p.getIRI())) {
                 builder.addXref(new XrefPropertyValue.Builder().val(val).build());
+            } else if (isExactMatchProperty(p.getIRI())) {
+                builder.addXref(new XrefPropertyValue.Builder().val(val).pred("exactMatch").build());
             } else if (isInSubsetProperty(p.getIRI())) {
                 builder.addSubset(val);
             } else if (isHasSynonymTypeProperty(p.getIRI())) {
@@ -633,6 +614,13 @@ public class FromOwl {
             builder.version(version);
         }
         return builder.build();
+    }
+
+    private Meta buildBasicPropertyValueMeta(Meta existingMeta) {
+        List<BasicPropertyValue> basicPropertyValues = existingMeta.basicPropertyValues();
+        return basicPropertyValues.isEmpty() ? null : new Meta.Builder()
+                .addAllBasicPropertyValues(basicPropertyValues)
+                .build();
     }
 
     private Meta nullIfEmpty(Meta meta) {
@@ -654,13 +642,12 @@ public class FromOwl {
 
     @Nullable
     private ExistentialRestrictionExpression getRestriction(OWLClassExpression x) {
-        if (x instanceof OWLObjectSomeValuesFrom) {
-            OWLObjectSomeValuesFrom r = (OWLObjectSomeValuesFrom) x;
+        if (x instanceof OWLObjectSomeValuesFrom r) {
             OWLPropertyExpression p = r.getProperty();
             OWLClassExpression f = r.getFiller();
-            if (p instanceof OWLObjectProperty && !f.isAnonymous()) {
+            if (p instanceof OWLObjectProperty owlObjectProperty && !f.isAnonymous()) {
                 return new ExistentialRestrictionExpression.Builder()
-                        .propertyId(getPropertyId((OWLObjectProperty) p))
+                        .propertyId(getPropertyId(owlObjectProperty))
                         .fillerId(getClassId((OWLClass) f))
                         .build();
             }
@@ -737,6 +724,14 @@ public class FromOwl {
 
     public boolean isHasXrefProperty(IRI iri) {
         return iri.toString().equals("http://www.geneontology.org/formats/oboInOwl#hasDbXref");
+    }
+
+    public boolean isExactMatchProperty(IRI iri) {
+        return iri.toString().equals("http://www.w3.org/2004/02/skos/core#exactMatch");
+    }
+
+    public boolean isRelatedMatchProperty(IRI iri) {
+        return iri.toString().equals("http://www.w3.org/2004/02/skos/core#relatedMatch");
     }
 
     public boolean isInSubsetProperty(IRI iri) {

--- a/obographs-owlapi/src/main/java/org/geneontology/obographs/owlapi/SynonymVocabulary.java
+++ b/obographs-owlapi/src/main/java/org/geneontology/obographs/owlapi/SynonymVocabulary.java
@@ -1,43 +1,29 @@
 package org.geneontology.obographs.owlapi;
 
-import org.geneontology.obographs.core.model.meta.AbstractSynonymPropertyValue.SCOPES;
+import org.geneontology.obographs.core.model.meta.AbstractSynonymPropertyValue.Scope;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class SynonymVocabulary {
 
     public static final String SYNONYM_TYPE = "http://www.geneontology.org/formats/oboInOwl#hasSynonymType";
 
-    Map<String,SCOPES> iriToScopeMap = new HashMap<>();
+    private static final Map<String, Scope> iriToScopeMap = Map.of(
+            "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym", Scope.EXACT,
+            "http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym", Scope.RELATED,
+            "http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym", Scope.NARROW,
+            "http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym", Scope.BROAD
+    );
 
-    
-    public SynonymVocabulary() {
-        super();
-        setDefaults();
-    }
-
-    public void setDefaults() {
-        set("http://www.geneontology.org/formats/oboInOwl#hasExactSynonym", SCOPES.EXACT);
-        set("http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym", SCOPES.RELATED);
-        set("http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym", SCOPES.NARROW);
-        set("http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym", SCOPES.BROAD);
+    private SynonymVocabulary() {
+        // utility class
     }
 
-    /**
-     * @return the iriToScopeMap
-     */
-    public Map<String, SCOPES> getIriToScopeMap() {
-        return iriToScopeMap;
-    }
-    
-    public void set(String iri, SCOPES scope) {
-        iriToScopeMap.put(iri, scope);
-    }
-    public SCOPES get(String iri) {
+    public static Scope getScope(String iri) {
         return iriToScopeMap.get(iri);
     }
-    public boolean contains(String iri) {
+
+    public static boolean containsIri(String iri) {
         return iriToScopeMap.containsKey(iri);
     }
 

--- a/obographs-owlapi/src/test/java/org/geneontology/obographs/owlapi/FromOwlTest.java
+++ b/obographs-owlapi/src/test/java/org/geneontology/obographs/owlapi/FromOwlTest.java
@@ -1,23 +1,21 @@
 package org.geneontology.obographs.owlapi;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.io.FileUtils;
 import org.geneontology.obographs.core.io.OgJsonGenerator;
 import org.geneontology.obographs.core.io.OgJsonReader;
 import org.geneontology.obographs.core.io.OgYamlGenerator;
 import org.geneontology.obographs.core.io.OgYamlReader;
 import org.geneontology.obographs.core.model.*;
-import org.geneontology.obographs.core.model.AbstractNode.PropertyType;
+import org.geneontology.obographs.core.model.PropertyType;
 import org.geneontology.obographs.core.model.meta.BasicPropertyValue;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 
 import java.io.*;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,7 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import static org.geneontology.obographs.core.model.AbstractNode.RDFTYPES.*;
+import static org.geneontology.obographs.core.model.RdfType.*;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -47,7 +45,9 @@ public class FromOwlTest {
      * to be run again otherwise the tests will (should!) fail.
      * @throws Exception
      */
-    public void createExampleFiles() throws Exception {
+    @Test
+    @Disabled("Only to be run manually when examples directory needs updating due to change in expected obograph file output")
+    void createExampleFiles() throws Exception {
         System.out.println("Creating example files in examples/ directory");
         for (File file : getTestOboOwlFiles()) {
             System.out.println("Loading " + file.getPath());
@@ -87,7 +87,7 @@ public class FromOwlTest {
             GraphDocument testGraphDocument = new FromOwl().generateGraphDocument(ontology);
             String strippedFileName = stripOboOwlExtensionFromFileName(file);
 
-            List<String> formats = Arrays.asList(".json", ".yaml");
+            List<String> formats = List.of(".json", ".yaml");
             for (String format : formats) {
                 System.out.println("Checking " + strippedFileName + format);
                 Path exampleFile = examplesPath.resolve(strippedFileName + format);
@@ -102,13 +102,11 @@ public class FromOwlTest {
     }
 
     private GraphDocument readGraphDocumentFrom(Path newFilePath, String format) throws IOException {
-        switch (format) {
-            case ".json":
-                return OgJsonReader.readFile(newFilePath.toFile());
-            case ".yaml":
-                return OgYamlReader.readFile(newFilePath.toFile());
-        }
-        throw new IllegalArgumentException("Format '" + format + "' not recognised");
+        return switch (format) {
+            case ".json" -> OgJsonReader.readFile(newFilePath.toFile());
+            case ".yaml" -> OgYamlReader.readFile(newFilePath.toFile());
+            default -> throw new IllegalArgumentException("Format '" + format + "' not recognised");
+        };
     }
 
     private Path writeNewTempFileWithFormat(GraphDocument gd, String strippedFileName, String format) throws IOException {
@@ -139,10 +137,10 @@ public class FromOwlTest {
             int line = 1;
             while (line1 != null && line2 != null) {
                 if (!line1.equals(line2)) {
-                    System.out.println("Mismatch at line: " + line);
+                    System.out.println("Mismatch at " + newFile + " line " + line + " when comparing to " + originalFile);
                     System.out.println("Exp: " + line1);
                     System.out.println("Got: " + line2);
-                    fail("Mismatch at " + newFile + " line " + line);
+                    fail("Mismatch at " + newFile + " line " + line + " when comparing to " + originalFile);
                 }
                 line++;
                 line1 = br1.readLine();
@@ -171,46 +169,48 @@ public class FromOwlTest {
 
     @Test
     public void testMissingNestedRestrictions() throws Exception {
-        String axiom = "<?xml version=\"1.0\"?>\n" +
-                "<rdf:RDF xmlns=\"http://purl.obolibrary.org/obo/uberon.owl#\"\n" +
-                "     xml:base=\"http://purl.obolibrary.org/obo/uberon.owl\"\n" +
-                "     xmlns:obo=\"http://purl.obolibrary.org/obo/\"\n" +
-                "     xmlns:oboInOwl=\"http://www.geneontology.org/formats/oboInOwl#\"\n" +
-                "     xmlns:owl=\"http://www.w3.org/2002/07/owl#\"\n" +
-                "     xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
-                "    <owl:Ontology rdf:about=\"http://purl.obolibrary.org/obo/uberon.owl\">\n" +
-                "        <owl:versionIRI rdf:resource=\"http://purl.obolibrary.org/obo/uberon/releases/2022-12-13/uberon.owl\"/>\n" +
-                "    </owl:Ontology>\n" +
-                "    \n<owl:Axiom>\n" +
-                "        <owl:annotatedSource rdf:resource=\"http://purl.obolibrary.org/obo/UBERON_0009551\"/>\n" +
-                "        <owl:annotatedProperty rdf:resource=\"http://www.w3.org/2002/07/owl#equivalentClass\"/>\n" +
-                "        <owl:annotatedTarget>\n" +
-                "            <owl:Class>\n" +
-                "                <owl:intersectionOf rdf:parseType=\"Collection\">\n" +
-                "                    <rdf:Description rdf:about=\"http://purl.obolibrary.org/obo/UBERON_0002529\"/>\n" +
-                "                    <owl:Restriction>\n" +
-                "                        <owl:onProperty rdf:resource=\"http://purl.obolibrary.org/obo/BFO_0000050\"/>\n" +
-                "                        <owl:someValuesFrom rdf:resource=\"http://purl.obolibrary.org/obo/UBERON_0002544\"/>\n" +
-                "                    </owl:Restriction>\n" +
-                "                    <owl:Restriction>\n" +
-                "                        <owl:onProperty rdf:resource=\"http://purl.obolibrary.org/obo/BFO_0000051\"/>\n" +
-                "                        <owl:someValuesFrom rdf:resource=\"http://purl.obolibrary.org/obo/UBERON_0004300\"/>\n" +
-                "                    </owl:Restriction>\n" +
-                "                    <owl:Restriction>\n" +
-                "                        <owl:onProperty rdf:resource=\"http://purl.obolibrary.org/obo/BFO_0000051\"/>\n" +
-                "                        <owl:someValuesFrom>\n" +
-                "                            <owl:Restriction>\n" +
-                "                                <owl:onProperty rdf:resource=\"http://purl.obolibrary.org/obo/BFO_0000050\"/>\n" +
-                "                                <owl:someValuesFrom rdf:resource=\"http://purl.obolibrary.org/obo/UBERON_0009768\"/>\n" +
-                "                            </owl:Restriction>\n" +
-                "                        </owl:someValuesFrom>\n" +
-                "                    </owl:Restriction>\n" +
-                "                </owl:intersectionOf>\n" +
-                "            </owl:Class>\n" +
-                "        </owl:annotatedTarget>\n" +
-                "        <oboInOwl:source>cjm</oboInOwl:source>\n" +
-                "    </owl:Axiom>\n" +
-                "</rdf:RDF>";
+        String axiom = """
+                <?xml version="1.0"?>
+                <rdf:RDF xmlns="http://purl.obolibrary.org/obo/uberon.owl#"
+                     xml:base="http://purl.obolibrary.org/obo/uberon.owl"
+                     xmlns:obo="http://purl.obolibrary.org/obo/"
+                     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
+                     xmlns:owl="http://www.w3.org/2002/07/owl#"
+                     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/uberon.owl">
+                        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/uberon/releases/2022-12-13/uberon.owl"/>
+                    </owl:Ontology>
+                    <owl:Axiom>
+                        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0009551"/>
+                        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+                        <owl:annotatedTarget>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002529"/>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002544"/>
+                                    </owl:Restriction>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004300"/>
+                                    </owl:Restriction>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                                        <owl:someValuesFrom>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0009768"/>
+                                            </owl:Restriction>
+                                        </owl:someValuesFrom>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:annotatedTarget>
+                        <oboInOwl:source>cjm</oboInOwl:source>
+                    </owl:Axiom>
+                </rdf:RDF>
+                """;
         GraphDocument graphDocument = generateGraphDocument(axiom);
         System.out.println(OgYamlGenerator.render(graphDocument));
     }
@@ -220,23 +220,25 @@ public class FromOwlTest {
      */
     @Test
     public void testClassDeclarationsWithoutFurtherAssertionsShouldBeIncludedInOboGraph() throws Exception {
-        String owlFile = "Prefix(:=<http://www.semanticweb.org/matentzn/ontologies/2021/11/untitled-ontology-544#>)\n" +
-                         "Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\n" +
-                         "Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)\n" +
-                         "Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)\n" +
-                         "Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\n" +
-                         "Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)\n" +
-                         "\n" +
-                         "\n" +
-                         "Ontology(<http://www.semanticweb.org/matentzn/ontologies/2021/11/untitled-ontology-544>\n" +
-                         "\n" +
-                         "Declaration(Class(<http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000060>))\n" +
-                         ")";
+        String owlFile = """
+                         Prefix(:=<http://www.semanticweb.org/matentzn/ontologies/2021/11/untitled-ontology-544#>)
+                         Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+                         Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+                         Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+                         Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+                         Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+                         
+                         
+                         Ontology(<http://www.semanticweb.org/matentzn/ontologies/2021/11/untitled-ontology-544>
+                         
+                         Declaration(Class(<http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000060>))
+                         )
+                         """;
 
         GraphDocument actual = generateGraphDocument(owlFile);
 
         Graph.Builder graphBuilder = new Graph.Builder().id("http://www.semanticweb.org/matentzn/ontologies/2021/11/untitled-ontology-544")
-                .addNode(new Node.Builder().id("http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000060").type(CLASS).build());
+                .addNode(new Node.Builder().id("http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000060").rdfType(CLASS).build());
         assertThat(actual, equalTo(new GraphDocument.Builder().addGraph(graphBuilder.build()).build()));
     }
 
@@ -245,36 +247,37 @@ public class FromOwlTest {
      */
     @Test
     public void testComplexPropertyExpressionLogsWarning() throws Exception {
-        var rdf = "<?xml version=\"1.0\"?>\n" +
-                  "<rdf:RDF xmlns=\"http://purl.obolibrary.org/obo/fail-expression.owl#\"\n" +
-                  "     xml:base=\"http://purl.obolibrary.org/obo/fail-expression.owl\"\n" +
-                  "     xmlns:owl=\"http://www.w3.org/2002/07/owl#\"\n" +
-                  "     xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n" +
-                  "     xmlns:xml=\"http://www.w3.org/XML/1998/namespace\"\n" +
-                  "     xmlns:xsd=\"http://www.w3.org/2001/XMLSchema#\"\n" +
-                  "     xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\">\n" +
-                  "    <owl:Ontology rdf:about=\"http://purl.obolibrary.org/obo/fail-expression.owl\">\n" +
-                  "    </owl:Ontology>\n" +
-                  "    \n" +
-                  "    <owl:Class rdf:about=\"http://purl.obolibrary.org/obo/OBI_0000260\">\n" +
-                  "        \n" +
-                  "        <rdfs:subClassOf>\n" +
-                  "            <owl:Restriction>\n" +
-                  "                <owl:onProperty>\n" +
-                  "                    <rdf:Description>\n" +
-                  "                        <owl:inverseOf rdf:resource=\"http://purl.obolibrary.org/obo/COB_0000087\"/>\n" +
-                  "                    </rdf:Description>\n" +
-                  "                </owl:onProperty>\n" +
-                  "                <owl:allValuesFrom rdf:resource=\"http://purl.obolibrary.org/obo/COB_0000082\"/>\n" +
-                  "            </owl:Restriction>\n" +
-                  "        </rdfs:subClassOf>\n" +
-                  "    </owl:Class>\n" +
-                  "   \n" +
-                  "</rdf:RDF>";
+        var rdf = """
+                  <?xml version="1.0"?>
+                  <rdf:RDF xmlns="http://purl.obolibrary.org/obo/fail-expression.owl#"
+                       xml:base="http://purl.obolibrary.org/obo/fail-expression.owl"
+                       xmlns:owl="http://www.w3.org/2002/07/owl#"
+                       xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                       xmlns:xml="http://www.w3.org/XML/1998/namespace"
+                       xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+                       xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+                      <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/fail-expression.owl">
+                      </owl:Ontology>
+                  
+                      <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000260">
+                 
+                          <rdfs:subClassOf>
+                              <owl:Restriction>
+                                  <owl:onProperty>
+                                      <rdf:Description>
+                                          <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000087"/>
+                                      </rdf:Description>
+                                  </owl:onProperty>
+                                  <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/COB_0000082"/>
+                              </owl:Restriction>
+                          </rdfs:subClassOf>
+                      </owl:Class>
+                  </rdf:RDF>
+                  """;
 
         GraphDocument graphDocument = generateGraphDocument(rdf);
         Graph graph = new Graph.Builder().id("http://purl.obolibrary.org/obo/fail-expression.owl")
-                .addNode(new Node.Builder().id("http://purl.obolibrary.org/obo/OBI_0000260").type(CLASS).build())
+                .addNode(new Node.Builder().id("http://purl.obolibrary.org/obo/OBI_0000260").rdfType(CLASS).build())
                 .build();
         assertThat(graphDocument, equalTo(new GraphDocument.Builder().addGraph(graph).build()));
     }
@@ -284,25 +287,26 @@ public class FromOwlTest {
      */
     @Test
     public void testDataPropertyAssertionHandling() throws Exception {
-        String ttl = "@prefix skos: <http://www.w3.org/2004/02/skos/core#> .\n" +
-                         "@prefix owl:  <http://www.w3.org/2002/07/owl#> .\n" +
-                         "@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .\n" +
-                         "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n" +
-                         "\n" +
-                         "<http://foo.com/bar> a owl:Class ;\n" +
-                         "        skos:prefLabel \"\"\"some node\"\"\"@en ;\n" +
-                         "        <http://foo.com/baz> \"\"\"test property\"\"\"^^xsd:string ;\n" +
-                         ".\n" +
-                         "\n" +
-                         "<http://foo.com/baz> a owl:DatatypeProperty ;\n" +
-                         "    rdfs:label \"\"\"test label\"\"\";\n" +
-                         "    rdfs:comment \"\"\"test comment\"\"\" .";
+        String ttl = """
+                         @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+                         @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+                         @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+                         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+                         
+                         <http://foo.com/bar> a owl:Class ;
+                             skos:prefLabel  "some node"@en ;
+                             <http://foo.com/baz> "test property"^^xsd:string .
+                         
+                         <http://foo.com/baz> a owl:DatatypeProperty ;
+                             rdfs:label "test label" ;
+                             rdfs:comment "test comment" .
+                         """;
 
         GraphDocument graphDocument = generateGraphDocument(ttl);
 //        System.out.println(OgYamlGenerator.render(graphDocument));
         Graph graph = new Graph.Builder()
-                .addNode(new Node.Builder().id("http://foo.com/bar").type(CLASS).meta(new Meta.Builder().addBasicPropertyValue(new BasicPropertyValue.Builder().pred("http://www.w3.org/2004/02/skos/core#prefLabel").val("some node").build()).build()).build())
-                .addNode(new Node.Builder().id("http://foo.com/baz").type(PROPERTY).propertyType(PropertyType.DATA).label("test label").meta(new Meta.Builder().addComment("test comment").build()).build())
+                .addNode(new Node.Builder().id("http://foo.com/bar").rdfType(CLASS).meta(new Meta.Builder().addBasicPropertyValue(new BasicPropertyValue.Builder().pred("http://www.w3.org/2004/02/skos/core#prefLabel").val("some node").build()).build()).build())
+                .addNode(new Node.Builder().id("http://foo.com/baz").rdfType(PROPERTY).propertyType(PropertyType.DATA).label("test label").meta(new Meta.Builder().addComment("test comment").build()).build())
                 .build();
         assertThat(graphDocument, equalTo(new GraphDocument.Builder().addGraph(graph).build()));
     }
@@ -312,29 +316,31 @@ public class FromOwlTest {
      */
     @Test
     public void testPropertiesHaveTypes() throws Exception{
-        String owl = "Prefix(:=<http://www.semanticweb.org/matentzn/ontologies/2021/11/untitled-ontology-544#>)\n" +
-                     "Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\n" +
-                     "Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)\n" +
-                     "Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)\n" +
-                     "Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\n" +
-                     "Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)\n" +
-                     "\n" +
-                     "\n" +
-                     "Ontology(<http://www.semanticweb.org/matentzn/ontologies/2021/11/untitled-ontology-544>\n" +
-                     "\n" +
-                     "Declaration(Class(<http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000059>))\n" +
-                     "Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000060>))\n" +
-                     "Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000061>))\n" +
-                     "Declaration(DataProperty(<http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000062>))\n" +
-                     ")";
+        String owl = """
+                     Prefix(:=<http://www.semanticweb.org/matentzn/ontologies/2021/11/untitled-ontology-544#>)
+                     Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+                     Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+                     Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+                     Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+                     Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+                     
+                     
+                     Ontology(<http://www.semanticweb.org/matentzn/ontologies/2021/11/untitled-ontology-544>
+                     
+                     Declaration(Class(<http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000059>))
+                     Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000060>))
+                     Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000061>))
+                     Declaration(DataProperty(<http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000062>))
+                     )
+                     """;
         GraphDocument graphDocument = generateGraphDocument(owl);
         System.out.println(OgYamlGenerator.render(graphDocument));
         Graph graph = new Graph.Builder().id("http://www.semanticweb.org/matentzn/ontologies/2021/11/untitled-ontology-544")
-                .addNode(new Node.Builder().id("http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000059").type(CLASS).build())
+                .addNode(new Node.Builder().id("http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000059").rdfType(CLASS).build())
                 // owlapi sort order - don't change this!
-                .addNode(new Node.Builder().id("http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000061").type(PROPERTY).propertyType(PropertyType.OBJECT).build())
-                .addNode(new Node.Builder().id("http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000062").type(PROPERTY).propertyType(PropertyType.DATA).build())
-                .addNode(new Node.Builder().id("http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000060").type(PROPERTY).propertyType(PropertyType.ANNOTATION).build())
+                .addNode(new Node.Builder().id("http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000061").rdfType(PROPERTY).propertyType(PropertyType.OBJECT).build())
+                .addNode(new Node.Builder().id("http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000062").rdfType(PROPERTY).propertyType(PropertyType.DATA).build())
+                .addNode(new Node.Builder().id("http://purl.obolibrary.org/obo/upheno/workshop2021/TMP_0000060").rdfType(PROPERTY).propertyType(PropertyType.ANNOTATION).build())
                 .build();
         assertThat(graphDocument, equalTo(new GraphDocument.Builder().addGraph(graph).build()));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.geneontology.obographs</groupId>
     <artifactId>obographs</artifactId>
-    <version>0.3.1</version>
+    <version>0.4.0</version>
     <modules>
         <module>obographs-core</module>
         <module>obographs-owlapi</module>
@@ -28,6 +28,12 @@
             <organization>Gene Ontology</organization>
             <organizationUrl>http://geneontology.org</organizationUrl>
         </developer>
+        <developer>
+            <name>Jules Jacobsen</name>
+            <email>j.jacobsen@qmul.ac.uk</email>
+            <organization>Queen Mary University of London</organization>
+            <organizationUrl>https://qmul.ac.uk/whri</organizationUrl>
+        </developer>
     </developers>
     <scm>
         <connection>scm:git:https://github.com/geneontology/obographs.git</connection>
@@ -43,9 +49,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>11</java.version>
-        <jackson.version>2.12.7</jackson.version>
-        <junit.jupiter.version>5.3.0</junit.jupiter.version>
+        <java.version>21</java.version>
+        <jackson.version>2.19.2</jackson.version>
     </properties>
 
     <distributionManagement>
@@ -63,7 +68,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.2.7</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -75,14 +80,14 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -94,28 +99,55 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.6.3</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>${java.version}</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.14.0</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.5.3</version>
                 <configuration>
+                    <useModulePath>false</useModulePath>
                     <excludes>
                         <exclude>**/FooTest.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-wrapper-plugin</artifactId>
+                <version>3.3.2</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -129,7 +161,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.11.2</version>
                 <configuration>
                     <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
                     <doclint>none</doclint>
@@ -148,32 +180,62 @@
         </plugins>
     </build>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>2.0.17</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.5.13</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.5.13</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>5.3.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>2.2</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>2.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/schema/obographs-schema.json
+++ b/schema/obographs-schema.json
@@ -3,7 +3,8 @@
   "id" : "urn:jsonschema:org:geneontology:obographs:core:model:GraphDocument",
   "properties" : {
     "@context" : {
-      "type" : "any"
+      "type" : "object",
+      "id" : "urn:jsonschema:java:lang:Object"
     },
     "meta" : {
       "type" : "object",


### PR DESCRIPTION
Mega 'ungettify' of the library. This *only* affects the core Java library and the FromOwl class. For example Previously the API would be: 
```int numNodes = graphDocument.getGraphs().get(0).getNodes().size();```
which is a whole lot of getting. Now, following the Java record-style, it reads:
```int numNodes = graphDocument.graphs().get(0).nodes().size();```.

**THIS IS ONLY A BREAKING CHANGE FOR THOSE USING THE OBOGRAPHS-CORE JAVA LIBRARY PROGRAMMATICALLY. All JSON serialisation is unaffected.**

Refactored the tests to use modern Java immutable collections.

Refactored FromOwl to use Java 21 'enhanced switch' pattern matching to hopefully radically clarify what is going on in there. Take a look, it's almost beautiful...

The files in examples were re-generated and are unchanged (see, not part of this PR) so FromOwl is working as it was before, only it's been to the gym, lost a few pounds and now sports a fine Savile Row suit (or at least a clean T-shirt with no holes in).

Given the API change, the version has been bumped 0.3.2 -> 0.4.0, although the OWL -> JSON functionality is unchanged. 